### PR TITLE
Generating a Shared Library wrapper for DBPS Remote

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,3 +162,38 @@ target_include_directories(dbpa_remote_testapp PRIVATE
   src/common
   src/common/tcb
 )
+
+# #########################################################
+# Create the shared library (*.so) for the dbps client.
+# #########################################################
+
+# Create dynamic library with core components
+add_library(dbps_client_lib SHARED
+  src/common/dbps_remote_shared_lib_wrapper.cpp
+  src/common/dbpa_remote.cpp
+  src/client/dbps_api_client.cpp
+  src/client/httplib_client.cpp
+  src/common/json_request.cpp
+  src/common/enum_utils.cpp
+)
+
+# Set library properties
+set_target_properties(dbps_client_lib PROPERTIES
+  VERSION 1.0.0
+  SOVERSION 1
+  OUTPUT_NAME "dbpsClient"
+)
+
+# Include directories for the library
+# TODO: are these needed?
+target_include_directories(dbps_client_lib PUBLIC
+  ${CMAKE_BINARY_DIR}/_deps/cppcodec-src
+  ${CMAKE_BINARY_DIR}/_deps/crow-src/include
+  ${CMAKE_BINARY_DIR}/_deps/httplib-src
+
+  src/common
+  src/common/tcb
+)
+
+# Export symbols for the library
+#target_compile_definitions(dbps_client_lib PRIVATE DBPS_EXPORTS)

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -127,7 +127,14 @@ void RemoteDataBatchProtectionAgent::init(
         }
         server_url_ = *server_url_opt;
         std::cerr << "INFO: RemoteDataBatchProtectionAgent::init() - server_url extracted: [" << server_url_ << "]" << std::endl;
-        
+
+        // check for app_context not empty (as user_id will be extracted from it)
+        if (app_context_.empty()) { 
+            std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - app_context is empty" << std::endl;
+            initialized_ = "Agent not properly initialized - app_context is empty";
+            return;
+        }
+
         // Extract user_id from app_context
         auto user_id_opt = ExtractUserId(app_context_);
         if (!user_id_opt || user_id_opt->empty()) {
@@ -239,10 +246,6 @@ std::optional<std::string> RemoteDataBatchProtectionAgent::ExtractServerUrl(cons
 }
 
 std::optional<std::string> RemoteDataBatchProtectionAgent::ExtractUserId(const std::string& app_context) const {
-    if (app_context.empty()) {
-        std::cerr << "ERROR: RemoteDataBatchProtectionAgent::ExtractUserId() - app_context is empty" << std::endl;
-        return std::nullopt;
-    }
     try {
         auto json = nlohmann::json::parse(app_context);
         if (json.contains("user_id") && json["user_id"].is_string()) {

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -240,6 +240,7 @@ std::optional<std::string> RemoteDataBatchProtectionAgent::ExtractServerUrl(cons
 
 std::optional<std::string> RemoteDataBatchProtectionAgent::ExtractUserId(const std::string& app_context) const {
     if (app_context.empty()) {
+        std::cerr << "ERROR: RemoteDataBatchProtectionAgent::ExtractUserId() - app_context is empty" << std::endl;
         return std::nullopt;
     }
     try {

--- a/src/common/dbps_remote_shared_lib_wrapper.cpp
+++ b/src/common/dbps_remote_shared_lib_wrapper.cpp
@@ -1,0 +1,14 @@
+#include <iostream>
+#include "dbpa_remote.h"
+#include "dbpa_interface.h"
+
+//TODO: should this be in a specific namespace?
+
+// Export function for creating new instances of DBPARemotefrom shared library
+extern "C" {
+    DataBatchProtectionAgentInterface* create_new_instance() {
+        std::cout << "Inside [extern \"C\"] --Creating new instance of DBPARemote" << std::endl;
+        return new dbps::external::RemoteDataBatchProtectionAgent();
+    }
+} // extern "C"
+


### PR DESCRIPTION
This generates the Shared Library (`libdbpsClient.so`) object locally.
This has been tested by loading the object into the Arrow codebase via the miniApp, where DBPS Remote was loaded, instantiated and successfully used for Encrypt/Decrypt. 

Additional tests will come in a later PR (e.g. unit tests for the symbols in the *.so file)