### PR TITLE
Rolling back to eliminate the option to use simple xor encryption

### DIFF
--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -233,23 +233,17 @@ std::vector<uint8_t> DataBatchEncryptionSequencer::EncryptData(const std::vector
     
     std::vector<uint8_t> encrypted_data(data.size());
 
-    if (USE_SIMPLE_XOR_ENCRYPTION) {
-        for (size_t i = 0; i < data.size(); ++i) {
-            encrypted_data[i] = data[i] ^ 0xAA;
-        }
+    // Generate a simple key from key_id by hashing it
+    std::hash<std::string> hasher;
+    size_t key_hash = hasher(key_id_);
+    
+    // XOR each byte with the key hash
+    for (size_t i = 0; i < data.size(); ++i) {
+        encrypted_data[i] = data[i] ^ (key_hash & 0xFF);
+        // Rotate the key hash for next byte
+        key_hash = (key_hash << 1) | (key_hash >> 31);
     }
-    else {
-        // Generate a simple key from key_id by hashing it
-        std::hash<std::string> hasher;
-        size_t key_hash = hasher(key_id_);
-        
-        // XOR each byte with the key hash
-        for (size_t i = 0; i < data.size(); ++i) {
-            encrypted_data[i] = data[i] ^ (key_hash & 0xFF);
-            // Rotate the key hash for next byte
-            key_hash = (key_hash << 1) | (key_hash >> 31);
-        }
-    }    
+
     return encrypted_data;
 }
 

--- a/src/server/encryption_sequencer.h
+++ b/src/server/encryption_sequencer.h
@@ -59,7 +59,6 @@ public:
     bool ConvertAndDecrypt(const std::string& ciphertext);
 
 public:
-    static const bool USE_SIMPLE_XOR_ENCRYPTION = true;
     static const bool CHECK_COMPRESSION_ENUM = false;
 
 private:

--- a/src/server/encryption_sequencer_test.cpp
+++ b/src/server/encryption_sequencer_test.cpp
@@ -459,12 +459,10 @@ bool TestRoundTripEncryption() {
             return false;
         }
         
-        if (!DataBatchEncryptionSequencer::USE_SIMPLE_XOR_ENCRYPTION) {
-            // Key-aware XOR encryption should produce different results for different keys
-            if (sequencer1.encrypted_result_ == sequencer2.encrypted_result_) {
-                std::cout << "Simple XOR encryption should produce different results for different keys" << std::endl;
-                return false;
-            }
+        // Key-aware XOR encryption should produce different results for different keys
+        if (sequencer1.encrypted_result_ == sequencer2.encrypted_result_) {
+            std::cout << "Simple XOR encryption should produce different results for different keys" << std::endl;
+            return false;
         }
         
         // But both should decrypt back to the same original


### PR DESCRIPTION
Rolling back to eliminate the option to use simple xor encryption. 

Testing: `encryption_sequencer_test` passes. Also tested manually with a remote client, server works as expected.