### PR TITLE
Updating DBPA interface and implementations for init() error throwing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,14 @@ FetchContent_Declare(
   GIT_TAG v3.1.0
 )
 
-FetchContent_MakeAvailable(crow cppcodec httplib nlohmann_json cxxopts)
+# Google Test for unit testing
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.14.0
+)
+
+FetchContent_MakeAvailable(crow cppcodec httplib nlohmann_json cxxopts googletest)
 
 # =============================================================================
 # Library Definitions
@@ -174,6 +181,7 @@ if(BUILD_TESTS)
     dbps_remote_lib
     dbps_client_lib
     dbps_common_lib
+    gtest_main
   )
 endif()
 

--- a/src/common/dbpa_interface.h
+++ b/src/common/dbpa_interface.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <stdexcept>
 #include "tcb/span.hpp"
 #include "enums.h"
 
@@ -16,6 +17,11 @@ using span = tcb::span<T>;
 #define DBPS_EXPORT
 #endif
 
+class DBPS_EXPORT DBPSException : public std::runtime_error {
+public:
+    explicit DBPSException(const std::string& message) : std::runtime_error(message) {}
+};
+
 namespace dbps::external {
 
 /*
@@ -23,8 +29,9 @@ namespace dbps::external {
  * - While handle to EncryptionResult/DecryptionResult exists, ciphertext()/plaintext() is guaranteed to return valid data
  * - Read operations are not destructive. Multiple calls return the same data
  * - Destructor must dispose of internal memory (either by delegation or cleanup)
- * - No throwing exceptions. Errors reported via success() flag and error methods.
  * - Library users must check size() to ensure the actual size of the returned payload.
+ * - Exceptions on init(): init() may throw DBPSException for initialization errors (e.g., invalid parameters, server connection failures)
+ * - Exceptions on Encrypt() and Decrypt(): Encrypt/Decrypt do not throw exceptions. Errors reported via success() flag and error methods.
  */
 
 class DBPS_EXPORT EncryptionResult {

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -123,7 +123,7 @@ void RemoteDataBatchProtectionAgent::init(
         if (!server_url_opt || server_url_opt->empty()) {
             std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - No server_url provided in connection_config." << std::endl;
             initialized_ = "Agent not properly initialized - server_url missing";
-            return;
+            throw DBPSException("No server_url provided in connection_config");
         }
         server_url_ = *server_url_opt;
         std::cerr << "INFO: RemoteDataBatchProtectionAgent::init() - server_url extracted: [" << server_url_ << "]" << std::endl;
@@ -132,7 +132,7 @@ void RemoteDataBatchProtectionAgent::init(
         if (app_context_.empty()) { 
             std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - app_context is empty" << std::endl;
             initialized_ = "Agent not properly initialized - app_context is empty";
-            return;
+            throw DBPSException("app_context is empty");
         }
 
         // Extract user_id from app_context
@@ -140,7 +140,7 @@ void RemoteDataBatchProtectionAgent::init(
         if (!user_id_opt || user_id_opt->empty()) {
             std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - No user_id provided in app_context." << std::endl;
             initialized_ = "Agent not properly initialized - user_id missing";
-            return;
+            throw DBPSException("No user_id provided in app_context");
         }
         user_id_ = *user_id_opt;
         std::cerr << "INFO: RemoteDataBatchProtectionAgent::init() - user_id extracted: [" << user_id_ << "]" << std::endl;
@@ -161,14 +161,17 @@ void RemoteDataBatchProtectionAgent::init(
         if (health_response != "OK") {
             std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - Health check returned unexpected response: " << health_response << std::endl;
             initialized_ = "Agent not properly initialized - healthz check failed";
-            return;
+            throw DBPSException("Health check failed: " + health_response);
         }
         std::cerr << "INFO: RemoteDataBatchProtectionAgent::init() - Health check successful: " << health_response << std::endl;
 
+    } catch (const DBPSException& e) {
+        // Re-throw DBPSException as-is.
+        throw;
     } catch (const std::exception& e) {
         std::cerr << "ERROR: RemoteDataBatchProtectionAgent::init() - Unexpected exception: " << e.what() << std::endl;
         initialized_ = "Agent not properly initialized - Unexpected exception: " + std::string(e.what());
-        return;
+        throw DBPSException("Unexpected exception during initialization: " + std::string(e.what()));
     }
 
     initialized_ = ""; // Empty string indicates successful initialization

--- a/src/common/dbpa_remote_test.cpp
+++ b/src/common/dbpa_remote_test.cpp
@@ -1,9 +1,9 @@
 #include "dbpa_remote.h"
 #include "../client/dbps_api_client.h"
 #include "../client/httplib_client.h"
-#include <iostream>
+#include <gtest/gtest.h>
 #include <memory>
-#include <cassert>
+#include <vector>
 
 using namespace dbps::external;
 
@@ -27,21 +27,6 @@ public:
     const std::string& get_user_id() const { return user_id_; }
     const std::optional<std::string>& get_initialized() const { return initialized_; }
 };
-
-// Test macro for simple assertions
-#define TEST_ASSERT(condition, message) \
-    do { \
-        if (!(condition)) { \
-            std::cerr << "FAILED: " << __FUNCTION__ << " - " << message << std::endl; \
-            return false; \
-        } \
-    } while(0)
-
-// Test macro for checking success
-#define TEST_PASS(test_name) \
-    do { \
-        std::cout << "PASS: " << test_name << std::endl; \
-    } while(0)
 
 // Mock HTTP client for testing
 class MockHttpClient : public HttpClientInterface {
@@ -85,250 +70,237 @@ public:
     }
 };
 
-// Test basic initialization with valid configuration
-bool TestBasicInitialization() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    mock_client->health_response = MockHttpClient::MockResponse(200, "OK", "");
+class RemoteDataBatchProtectionAgentTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        mock_client_ = std::make_unique<MockHttpClient>();
+    }
     
-    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client));
+    void TearDown() override {
+        mock_client_.reset();
+    }
+    
+    std::unique_ptr<MockHttpClient> mock_client_;
+};
+
+// Test basic initialization with valid configuration
+TEST_F(RemoteDataBatchProtectionAgentTest, BasicInitialization) {
+    mock_client_->health_response = MockHttpClient::MockResponse(200, "OK", "");
+    
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {{"server_url", "http://localhost:8080"}};
     std::string app_context = "{\"user_id\": \"test_user\"}";
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should not throw an exception for valid configuration
+    EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                               Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED));
     
     // Test that initialization variables are properly set
-    TEST_ASSERT(agent.get_column_name() == "test_column", "Column name should be set correctly");
-    TEST_ASSERT(agent.get_column_key_id() == "test_key", "Column key ID should be set correctly");
-    TEST_ASSERT(agent.get_data_type() == Type::BYTE_ARRAY, "Data type should be set correctly");
-    TEST_ASSERT(agent.get_compression_type() == CompressionCodec::UNCOMPRESSED, "Compression type should be set correctly");
+    EXPECT_EQ(agent.get_column_name(), "test_column");
+    EXPECT_EQ(agent.get_column_key_id(), "test_key");
+    EXPECT_EQ(agent.get_data_type(), Type::BYTE_ARRAY);
+    EXPECT_EQ(agent.get_compression_type(), CompressionCodec::UNCOMPRESSED);
     
     // Test that connection config and app context are accessible
-    TEST_ASSERT(agent.get_connection_config().find("server_url") != agent.get_connection_config().end(), "Connection config should contain server_url");
-    TEST_ASSERT(agent.get_connection_config().at("server_url") == "http://localhost:8080", "Server URL should be set correctly");
-    
-    TEST_ASSERT(agent.get_app_context() == app_context, "App context should be set correctly");
+    EXPECT_TRUE(agent.get_connection_config().find("server_url") != agent.get_connection_config().end());
+    EXPECT_EQ(agent.get_connection_config().at("server_url"), "http://localhost:8080");
+    EXPECT_EQ(agent.get_app_context(), app_context);
     
     // Test that RemoteDataBatchProtectionAgent specific variables are set
-    TEST_ASSERT(agent.get_server_url() == "http://localhost:8080", "Server URL should be extracted and set correctly");
-    TEST_ASSERT(agent.get_user_id() == "test_user", "User ID should be extracted from app_context and set correctly");
-    TEST_ASSERT(agent.get_initialized() == "", "Initialization should succeed with empty string (no error)");
-        
-    TEST_PASS("Basic Initialization");
-    return true;
+    EXPECT_EQ(agent.get_server_url(), "http://localhost:8080");
+    EXPECT_EQ(agent.get_user_id(), "test_user");
+    EXPECT_EQ(agent.get_initialized(), "");
 }
 
 // Test decryption without initialization
-bool TestDecryptWithoutInit() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client));
+TEST_F(RemoteDataBatchProtectionAgentTest, DecryptWithoutInit) {
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     // Don't call init() - leave agent uninitialized
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Decrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Decrypt result should not be null");
-    TEST_ASSERT(!result->success(), "Should fail due to not being initialized");
+    ASSERT_NE(result, nullptr);
+    EXPECT_FALSE(result->success());
     
     std::string error_msg = result->error_message();
-    TEST_ASSERT(error_msg.find("init() was not called") != std::string::npos, 
-                "Error should indicate initialization failure");
-    
-    TEST_PASS("Decrypt Without Init");
-    return true;
+    EXPECT_TRUE(error_msg.find("init() was not called") != std::string::npos);
 }
 
 // Test initialization with missing server URL
-bool TestMissingServerUrl() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    auto agent = RemoteDataBatchProtectionAgent(std::move(mock_client));
+TEST_F(RemoteDataBatchProtectionAgentTest, MissingServerUrl) {
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {}; // No server_url
     std::string app_context = "{\"user_id\": \"test_user\"}";
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should throw DBPSException for missing server URL
+    EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                            Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED), 
+                 DBPSException);
     
-    // Test that initialization failed
+    // Test that the initialized_ state reflects the failure
+    EXPECT_TRUE(agent.get_initialized().has_value());
+    EXPECT_FALSE(agent.get_initialized()->empty());
+    EXPECT_TRUE(agent.get_initialized()->find("server_url") != std::string::npos);
+    
+    // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Encrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Encrypt result should not be null");
-    TEST_ASSERT(!result->success(), "Should fail due to missing server URL");
+    ASSERT_NE(result, nullptr);
+    EXPECT_FALSE(result->success());
     
     // Check that the error message contains expected content
     std::string error_msg = result->error_message();
-    std::cerr << "DEBUG: Missing server URL test - error message: '" << error_msg << "'" << std::endl;
-    TEST_ASSERT(error_msg.find("initialized") != std::string::npos && 
-                error_msg.find("server_url") != std::string::npos,
-                "Error should indicate initialization and server URL failure");
-    
-    TEST_PASS("Missing Server URL");
-    return true;
+    EXPECT_TRUE(error_msg.find("initialized") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("server_url") != std::string::npos);
 }
 
 // Test initialization with missing user ID
-bool TestMissingUserId() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    auto agent = RemoteDataBatchProtectionAgent(std::move(mock_client));
+TEST_F(RemoteDataBatchProtectionAgentTest, MissingUserId) {
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {{"server_url", "http://localhost:8080"}};
     std::string app_context = "{}"; // No user_id
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should throw DBPSException for missing user ID
+    EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                            Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED), 
+                 DBPSException);
     
-    // Test that initialization failed
+    // Test that the initialized_ state reflects the failure
+    EXPECT_TRUE(agent.get_initialized().has_value());
+    EXPECT_FALSE(agent.get_initialized()->empty());
+    EXPECT_TRUE(agent.get_initialized()->find("user_id") != std::string::npos);
+    
+    // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Encrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Encrypt result should not be null");
-    TEST_ASSERT(!result->success(), "Should fail due to missing user ID");
+    ASSERT_NE(result, nullptr);
+    EXPECT_FALSE(result->success());
     
     // Check that the error message contains expected content
     std::string error_msg = result->error_message();
-    std::cerr << "DEBUG: Missing user ID test - error message: '" << error_msg << "'" << std::endl;
-    TEST_ASSERT(error_msg.find("initialized") != std::string::npos && 
-                error_msg.find("user_id") != std::string::npos,
-                "Error should indicate initialization and user ID failure");
-    
-    TEST_PASS("Missing User ID");
-    return true;
+    EXPECT_TRUE(error_msg.find("initialized") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("user_id") != std::string::npos);
 }
 
 // Test health check failure
-bool TestHealthCheckFailure() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    mock_client->health_response = MockHttpClient::MockResponse(500, "", "Server error");
+TEST_F(RemoteDataBatchProtectionAgentTest, HealthCheckFailure) {
+    mock_client_->health_response = MockHttpClient::MockResponse(500, "", "Server error");
     
-    auto agent = RemoteDataBatchProtectionAgent(std::move(mock_client));
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {{"server_url", "http://localhost:8080"}};
     std::string app_context = "{\"user_id\": \"test_user\"}";
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should throw DBPSException for health check failure
+    EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                            Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED), 
+                 DBPSException);
     
-    // Test that initialization failed due to health check
+    // Test that the initialized_ state reflects the failure
+    EXPECT_TRUE(agent.get_initialized().has_value());
+    EXPECT_FALSE(agent.get_initialized()->empty());
+    EXPECT_TRUE(agent.get_initialized()->find("healthz") != std::string::npos);
+    
+    // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Encrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Encrypt result should not be null");
-    TEST_ASSERT(!result->success(), "Should fail due to health check failure");
+    ASSERT_NE(result, nullptr);
+    EXPECT_FALSE(result->success());
     
     // Check that the error message contains expected content
     std::string error_msg = result->error_message();
-    std::cerr << "DEBUG: Health check failure test - error message: '" << error_msg << "'" << std::endl;
-    TEST_ASSERT(error_msg.find("initialized") != std::string::npos && 
-                error_msg.find("healthz") != std::string::npos,
-                "Error should indicate initialization and health check failure");
-    
-    TEST_PASS("Health Check Failure");
-    return true;
+    EXPECT_TRUE(error_msg.find("initialized") != std::string::npos);
+    EXPECT_TRUE(error_msg.find("healthz") != std::string::npos);
 }
 
 // Test successful encryption
-bool TestSuccessfulEncryption() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    mock_client->health_response = MockHttpClient::MockResponse(200, "OK", "");
-    mock_client->encrypt_response = MockHttpClient::MockResponse(
+TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulEncryption) {
+    mock_client_->health_response = MockHttpClient::MockResponse(200, "OK", "");
+    mock_client_->encrypt_response = MockHttpClient::MockResponse(
         200, 
-        "{\"access\":{\"user_id\":\"test_user\",\"role\":\"EmailReader\",\"access_control\":\"granted\"},\"debug\":{\"reference_id\":\"123\"},\"data_batch_encrypted\":{\"value_format\":{\"compression\":\"UNCOMPRESSED\"},\"value\":\"dGVzdF9kYXRh\"}}", 
+        "{\"access\":{\"user_id\":\"test_user\",\"role\":\"EmailReader\",\"access_control\":\"granted\"},"
+        "\"debug\":{\"reference_id\":\"123\"},"
+        "\"data_batch_encrypted\":{"
+        "\"value_format\":{\"compression\":\"UNCOMPRESSED\"},"
+        "\"value\":\"dGVzdF9kYXRh\""
+        "}}", 
         ""
     );
     
-    auto agent = RemoteDataBatchProtectionAgent(std::move(mock_client));
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {{"server_url", "http://localhost:8080"}};
     std::string app_context = "{\"user_id\": \"test_user\"}";
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should not throw an exception for valid configuration
+    EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                               Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Encrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Encrypt result should not be null");
-    if (!result->success()) {
-        std::cerr << "Encryption failed with error: " << result->error_message() << std::endl;
-        for (const auto& field : result->error_fields()) {
-            std::cerr << "  " << field.first << ": " << field.second << std::endl;
-        }
-    }
-    TEST_ASSERT(result->success(), "Encryption should succeed");
-    TEST_ASSERT(result->size() > 0, "Encrypted data should have size > 0");
-    TEST_ASSERT(result->ciphertext().size() > 0, "Encrypted data should have size > 0");
-    TEST_ASSERT(result->size() >= result->ciphertext().size(), "Encrypted data size should be >= than size of the ciphertext");
-    TEST_ASSERT(result->ciphertext().data() != nullptr, "Encrypted data should have non-null data");
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(result->success());
+    EXPECT_GT(result->size(), 0);
+    EXPECT_GT(result->ciphertext().size(), 0);
+    EXPECT_GE(result->size(), result->ciphertext().size());
+    EXPECT_NE(result->ciphertext().data(), nullptr);
     
     // Check that the encrypted data contains the expected content
-    std::string ciphertext_str(reinterpret_cast<const char*>(result->ciphertext().data()), result->ciphertext().size());
-    TEST_ASSERT(result->ciphertext().size() > 0, "Encrypted data should have size > 0");
-    TEST_ASSERT(ciphertext_str == "test_data", "Encrypted data should contain 'test_data'");
-    
-    TEST_PASS("Successful Encryption");
-    return true;
+    std::string ciphertext_str(reinterpret_cast<const char*>(result->ciphertext().data()), 
+                              result->ciphertext().size());
+    EXPECT_EQ(ciphertext_str, "test_data");
 }
 
 // Test successful decryption
-bool TestSuccessfulDecryption() {
-    auto mock_client = std::make_unique<MockHttpClient>();
-    mock_client->health_response = {200, "OK", ""};
-    mock_client->decrypt_response = MockHttpClient::MockResponse(
+TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulDecryption) {
+    mock_client_->health_response = {200, "OK", ""};
+    mock_client_->decrypt_response = MockHttpClient::MockResponse(
         200, 
-        "{\"access\":{\"user_id\":\"test_user\",\"role\":\"EmailReader\",\"access_control\":\"granted\"},\"debug\":{\"reference_id\":\"123\"},\"data_batch\":{\"datatype\":\"BYTE_ARRAY\",\"value_format\":{\"compression\":\"UNCOMPRESSED\",\"format\":\"RAW_C_DATA\",\"encoding\":\"BASE64\"},\"value\":\"dGVzdF9kYXRh\"}}", 
+        "{\"access\":{\"user_id\":\"test_user\",\"role\":\"EmailReader\",\"access_control\":\"granted\"},"
+        "\"debug\":{\"reference_id\":\"123\"},"
+        "\"data_batch\":{"
+        "\"datatype\":\"BYTE_ARRAY\","
+        "\"value_format\":{\"compression\":\"UNCOMPRESSED\",\"format\":\"RAW_C_DATA\",\"encoding\":\"BASE64\"},"
+        "\"value\":\"dGVzdF9kYXRh\""
+        "}}", 
         ""
     );
     
-    auto agent = RemoteDataBatchProtectionAgent(std::move(mock_client));
+    auto agent = TestableRemoteDataBatchProtectionAgent(std::move(mock_client_));
     
     std::map<std::string, std::string> connection_config = {{"server_url", "http://localhost:8080"}};
     std::string app_context = "{\"user_id\": \"test_user\"}";
     
-    agent.init("test_column", connection_config, app_context, "test_key", Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED);
+    // init() should not throw an exception for valid configuration
+    EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
+                               Type::BYTE_ARRAY, CompressionCodec::UNCOMPRESSED));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     auto result = agent.Decrypt(test_data);
     
-    TEST_ASSERT(result != nullptr, "Decrypt result should not be null");
-    if (!result->success()) {
-        std::cerr << "Decryption failed with error: " << result->error_message() << std::endl;
-        for (const auto& field : result->error_fields()) {
-            std::cerr << "  " << field.first << ": " << field.second << std::endl;
-        }
-    }
-    TEST_ASSERT(result->success(), "Decryption should succeed");
-    TEST_ASSERT(result->size() > 0, "Decrypted data should have size > 0");
-    TEST_ASSERT(result->plaintext().size() > 0, "Decrypted data should have size > 0");   
-    TEST_ASSERT(result->size() >= result->plaintext().size(), "Decrypted data size should be >= than size of the plaintext");
-    TEST_ASSERT(result->plaintext().data() != nullptr, "Decrypted data should have non-null data");
+    ASSERT_NE(result, nullptr);
+    EXPECT_TRUE(result->success());
+    EXPECT_GT(result->size(), 0);
+    EXPECT_GT(result->plaintext().size(), 0);
+    EXPECT_GE(result->size(), result->plaintext().size());
+    EXPECT_NE(result->plaintext().data(), nullptr);
     
     // Check that the decrypted data contains the expected content
-    std::string plaintext_str(reinterpret_cast<const char*>(result->plaintext().data()), result->plaintext().size());
-    TEST_ASSERT(result->plaintext().size() > 0, "Decrypted data should have size > 0");
-    TEST_ASSERT(plaintext_str == "test_data", "Decrypted data should contain 'test_data'");
-    
-    TEST_PASS("Successful Decryption");
-    return true;
+    std::string plaintext_str(reinterpret_cast<const char*>(result->plaintext().data()), 
+                             result->plaintext().size());
+    EXPECT_EQ(plaintext_str, "test_data");
 }
 
-// Main test runner
-int main() {
-    std::cout << "Running Remote DataBatchProtectionAgent tests..." << std::endl;
-    std::cout << "=============================================" << std::endl;
-    
-    bool all_tests_passed = true;
-    
-    all_tests_passed &= TestBasicInitialization();
-    all_tests_passed &= TestDecryptWithoutInit();
-    all_tests_passed &= TestMissingServerUrl();
-    all_tests_passed &= TestMissingUserId();
-    all_tests_passed &= TestHealthCheckFailure();
-    all_tests_passed &= TestSuccessfulEncryption();
-    all_tests_passed &= TestSuccessfulDecryption();
-    
-    std::cout << "=============================================" << std::endl;
-    if (all_tests_passed) {
-        std::cout << "All tests passed!" << std::endl;
-        return 0;
-    } else {
-        std::cout << "Some tests failed!" << std::endl;
-        return 1;
-    }
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Updated DBPA interface to indicate init() can throw exceptions.
- Updated DBPA_remote_test.cpp to throw exceptions on init().
- Updated tests for error throwing and updated to use Gtest framework.