### PR TITLE
Removing Encoding param from API payloads

### DIFF
--- a/src/client/dbps_api_client.cpp
+++ b/src/client/dbps_api_client.cpp
@@ -215,10 +215,6 @@ EncryptApiResponse DBPSApiClient::Encrypt(
     json_request.user_id_ = user_id;
     json_request.reference_id_ = GenerateReferenceId();
 
-    // TODO: Add support for other formats and encodings.
-    // Encode the plaintext as base64 and set the encoding param to BASE64.
-    json_request.encoding_ = std::string(to_string(Encoding::BASE64));
-    
     EncryptApiResponse api_response;
     try {
         // Encode the plaintext as base64 and set the value_ param.
@@ -302,10 +298,6 @@ DecryptApiResponse DBPSApiClient::Decrypt(
     json_request.user_id_ = user_id;
     json_request.reference_id_ = GenerateReferenceId();
 
-    // TODO: Add support for other formats and encodings.
-    // Encode the ciphertext as base64 and set the encoding param to BASE64.
-    json_request.encoding_ = std::string(to_string(Encoding::BASE64));
-    
     DecryptApiResponse api_response;
     try {
         // Encode the ciphertext as base64 and set the encrypted_value_ param and 

--- a/src/client/dbps_api_client_test.cpp
+++ b/src/client/dbps_api_client_test.cpp
@@ -213,7 +213,6 @@ TEST(DecryptApiResponseGetResponsePlaintextWithValidData) {
     json_response.datatype_ = "BYTE_ARRAY";
     json_response.compression_ = "UNCOMPRESSED";
     json_response.format_ = "RAW_C_DATA";
-    json_response.encoding_ = "BASE64";
     json_response.user_id_ = "test_user";
     json_response.role_ = "test_role";
     json_response.access_control_ = "test_access";
@@ -255,8 +254,7 @@ TEST(EncryptWithValidData) {
             "value": "dGVzdEBleGFtcGxlLmNvbQ==",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {
@@ -337,8 +335,7 @@ TEST(DecryptWithValidData) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {
@@ -356,8 +353,7 @@ TEST(DecryptWithValidData) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "access": {
@@ -510,8 +506,7 @@ TEST(EncryptWithInvalidBase64Response) {
             "value": "dGVzdEBleGFtcGxlLmNvbQ==",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {
@@ -577,8 +572,7 @@ TEST(DecryptWithInvalidBase64Response) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {
@@ -597,8 +591,7 @@ TEST(DecryptWithInvalidBase64Response) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "access": {
@@ -649,8 +642,7 @@ TEST(EncryptWithInvalidJsonResponse) {
             "value": "dGVzdEBleGFtcGxlLmNvbQ==",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {
@@ -709,8 +701,7 @@ TEST(DecryptWithInvalidJsonResponse) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "RAW_C_DATA",
-                "encoding": "BASE64"
+                "format": "RAW_C_DATA"
             }
         },
         "data_batch_encrypted": {

--- a/src/common/dbpa_remote_test.cpp
+++ b/src/common/dbpa_remote_test.cpp
@@ -268,7 +268,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulDecryption) {
         "\"debug\":{\"reference_id\":\"123\"},"
         "\"data_batch\":{"
         "\"datatype\":\"BYTE_ARRAY\","
-        "\"value_format\":{\"compression\":\"UNCOMPRESSED\",\"format\":\"RAW_C_DATA\",\"encoding\":\"BASE64\"},"
+        "\"value_format\":{\"compression\":\"UNCOMPRESSED\",\"format\":\"RAW_C_DATA\"},"
         "\"value\":\"dGVzdF9kYXRh\""
         "}}", 
         ""

--- a/src/common/enum_utils.cpp
+++ b/src/common/enum_utils.cpp
@@ -93,20 +93,4 @@ std::optional<F> to_format_enum(std::string_view s) {
     return lookup::from_string_impl<F>(s, kFormatPairs);
 }
 
-// For dbps::external::Encoding
-namespace {
-using E = ::dbps::external::Encoding::type;
-inline constexpr std::array<std::pair<E, std::string_view>, 2> kEncodingPairs{{
-    {E::UTF8, "UTF8"},
-    {E::BASE64, "BASE64"},
-}};
-} // anon
-
-std::string_view to_string(E v) {
-    return lookup::to_string_impl(v, kEncodingPairs);
-}
-std::optional<E> to_encoding_enum(std::string_view s) {
-    return lookup::from_string_impl<E>(s, kEncodingPairs);
-}
-
 }

--- a/src/common/enum_utils.h
+++ b/src/common/enum_utils.h
@@ -19,8 +19,4 @@ std::optional<::dbps::external::CompressionCodec::type> to_compression_enum(std:
 std::string_view to_string(::dbps::external::Format::type v);
 std::optional<::dbps::external::Format::type> to_format_enum(std::string_view s);
 
-// For dbps::external::Encoding
-std::string_view to_string(::dbps::external::Encoding::type v);
-std::optional<::dbps::external::Encoding::type> to_encoding_enum(std::string_view s);
-
 }

--- a/src/common/enum_utils_test.cpp
+++ b/src/common/enum_utils_test.cpp
@@ -190,38 +190,6 @@ TEST(FormatInvalidFromString) {
     ASSERT_FALSE(result.has_value());
 }
 
-// Test Encoding enum conversions
-TEST(EncodingToStringConversion) {
-    ASSERT_EQ("UTF8", std::string(to_string(Encoding::UTF8)));
-    ASSERT_EQ("BASE64", std::string(to_string(Encoding::BASE64)));
-}
-
-TEST(EncodingFromStringConversion) {
-    auto result = to_encoding_enum("UTF8");
-    ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(Encoding::UTF8, result.value());
-    
-    result = to_encoding_enum("BASE64");
-    ASSERT_TRUE(result.has_value());
-    ASSERT_EQ(Encoding::BASE64, result.value());
-}
-
-TEST(EncodingInvalidFromString) {
-    auto result = to_encoding_enum("INVALID");
-    ASSERT_FALSE(result.has_value());
-    
-    result = to_encoding_enum("utf8");  // lowercase
-    ASSERT_FALSE(result.has_value());
-    
-    result = to_encoding_enum("UTF-8");  // with hyphen
-    ASSERT_FALSE(result.has_value());
-    
-    result = to_encoding_enum("");
-    ASSERT_FALSE(result.has_value());
-    
-    result = to_encoding_enum("ASCII");  // common encoding
-    ASSERT_FALSE(result.has_value());
-}
 
 // Test round-trip conversions
 TEST(RoundTripTypeConversion) {
@@ -269,26 +237,12 @@ TEST(RoundTripFormatConversion) {
     }
 }
 
-TEST(RoundTripEncodingConversion) {
-    // Test all Encoding enum values
-    Encoding::type encodings[] = {
-        Encoding::UTF8, Encoding::BASE64
-    };
-    
-    for (auto encoding : encodings) {
-        auto str = to_string(encoding);
-        auto converted = to_encoding_enum(str);
-        ASSERT_TRUE(converted.has_value());
-        ASSERT_EQ(encoding, converted.value());
-    }
-}
 
 // Test edge cases
 TEST(EmptyStringHandling) {
     ASSERT_FALSE(to_datatype_enum("").has_value());
     ASSERT_FALSE(to_compression_enum("").has_value());
     ASSERT_FALSE(to_format_enum("").has_value());
-    ASSERT_FALSE(to_encoding_enum("").has_value());
 }
 
 TEST(WhitespaceHandling) {
@@ -331,13 +285,10 @@ TEST(RuntimeEvaluation) {
     auto type_str = to_string(Type::BYTE_ARRAY);
     auto codec_str = to_string(CompressionCodec::GZIP);
     auto format_str = to_string(Format::CSV);
-    auto encoding_str = to_string(Encoding::UTF8);
-    
     // Verify the results
     ASSERT_EQ("BYTE_ARRAY", std::string(type_str));
     ASSERT_EQ("GZIP", std::string(codec_str));
     ASSERT_EQ("CSV", std::string(format_str));
-    ASSERT_EQ("UTF8", std::string(encoding_str));
 }
 
 // Protection tests: ensure enum_utils stays in sync with enum definitions
@@ -395,30 +346,12 @@ TEST(FormatEnumCompleteness) {
     }
 }
 
-TEST(EncodingEnumCompleteness) {
-    // Define all known Encoding enum values
-    Encoding::type all_encodings[] = {
-        Encoding::UTF8, Encoding::BASE64
-    };
-    
-    // Test that every enum value can be converted to string and back
-    for (auto encoding : all_encodings) {
-        auto str = to_string(encoding);
-        ASSERT_TRUE(str != "UNKNOWN");  // Should not return UNKNOWN for valid enum
-        
-        auto converted = to_encoding_enum(str);
-        ASSERT_TRUE(converted.has_value());
-        ASSERT_EQ(encoding, converted.value());
-    }
-}
 
 TEST(StringUniqueness) {
     // Test that all string representations are unique
     std::set<std::string> type_strings;
     std::set<std::string> codec_strings;
     std::set<std::string> format_strings;
-    std::set<std::string> encoding_strings;
-    
     // Collect all Type strings
     Type::type all_types[] = {
         Type::BOOLEAN, Type::INT32, Type::INT64, Type::INT96,
@@ -449,14 +382,6 @@ TEST(StringUniqueness) {
     }
     ASSERT_EQ(3, format_strings.size());  // All strings should be unique
     
-    // Collect all Encoding strings
-    Encoding::type all_encodings[] = {
-        Encoding::UTF8, Encoding::BASE64
-    };
-    for (auto encoding : all_encodings) {
-        encoding_strings.insert(std::string(to_string(encoding)));
-    }
-    ASSERT_EQ(2, encoding_strings.size());  // All strings should be unique
 }
 
 TEST(CrossEnumStringCollision) {
@@ -488,15 +413,8 @@ TEST(CrossEnumStringCollision) {
         all_strings.insert(std::string(to_string(format)));
     }
     
-    Encoding::type all_encodings[] = {
-        Encoding::UTF8, Encoding::BASE64
-    };
-    for (auto encoding : all_encodings) {
-        all_strings.insert(std::string(to_string(encoding)));
-    }
-    
-    // Total should be 8 + 8 + 3 + 2 = 21 unique strings
-    ASSERT_EQ(21, all_strings.size());
+    // Total should be 8 + 8 + 3 = 19 unique strings
+    ASSERT_EQ(19, all_strings.size());
 }
 
 int main() {
@@ -517,16 +435,11 @@ int main() {
     test_FormatFromStringConversion();
     test_FormatInvalidFromString();
     
-    // Encoding enum tests
-    test_EncodingToStringConversion();
-    test_EncodingFromStringConversion();
-    test_EncodingInvalidFromString();
     
     // Round-trip tests
     test_RoundTripTypeConversion();
     test_RoundTripCompressionCodecConversion();
     test_RoundTripFormatConversion();
-    test_RoundTripEncodingConversion();
     
     // Edge case tests
     test_EmptyStringHandling();
@@ -539,7 +452,6 @@ int main() {
     test_TypeEnumCompleteness();
     test_CompressionCodecEnumCompleteness();
     test_FormatEnumCompleteness();
-    test_EncodingEnumCompleteness();
     test_StringUniqueness();
     test_CrossEnumStringCollision();
     

--- a/src/common/enums.h
+++ b/src/common/enums.h
@@ -40,12 +40,4 @@ struct Format {
     };
 };
 
-// Encoding applied to the data when serialized to send over the wire
-struct Encoding {
-    enum type {
-        UTF8 = 0,
-        BASE64 = 1
-    };
-};
-
 }

--- a/src/common/json_request.cpp
+++ b/src/common/json_request.cpp
@@ -63,9 +63,6 @@ void JsonRequest::ParseCommon(const std::string& request_body) {
     if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch", "value_format", "format"})) {
         format_ = *parsed_value;
     }
-    if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch", "value_format", "encoding"})) {
-        encoding_ = *parsed_value;
-    }
     if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch_encrypted", "value_format", "compression"})) {
         encrypted_compression_ = *parsed_value;
     }
@@ -85,7 +82,6 @@ bool JsonRequest::IsValid() const {
            !datatype_.empty() && 
            !compression_.empty() && 
            !format_.empty() && 
-           !encoding_.empty() && 
            !encrypted_compression_.empty() && 
            !key_id_.empty() && 
            !user_id_.empty() && 
@@ -99,7 +95,6 @@ std::string JsonRequest::GetValidationError() const {
     if (datatype_.empty()) missing_fields.push_back("data_batch.datatype");
     if (compression_.empty()) missing_fields.push_back("data_batch.value_format.compression");
     if (format_.empty()) missing_fields.push_back("data_batch.value_format.format");
-    if (encoding_.empty()) missing_fields.push_back("data_batch.value_format.encoding");
     if (encrypted_compression_.empty()) missing_fields.push_back("data_batch_encrypted.value_format.compression");
     if (key_id_.empty()) missing_fields.push_back("encryption.key_id");
     if (user_id_.empty()) missing_fields.push_back("access.user_id");
@@ -167,7 +162,6 @@ std::string EncryptJsonRequest::ToJsonString() const {
     crow::json::wvalue value_format;
     value_format["compression"] = compression_;
     value_format["format"] = format_;
-    value_format["encoding"] = encoding_;
     data_batch["value_format"] = std::move(value_format);
     
     json["data_batch"] = std::move(data_batch);
@@ -245,7 +239,6 @@ std::string DecryptJsonRequest::ToJsonString() const {
     crow::json::wvalue value_format;
     value_format["compression"] = compression_;
     value_format["format"] = format_;
-    value_format["encoding"] = encoding_;
     data_batch["value_format"] = std::move(value_format);
     
     json["data_batch"] = std::move(data_batch);
@@ -335,9 +328,6 @@ void DecryptJsonResponse::Parse(const std::string& response_body) {
     if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch", "value_format", "format"})) {
         format_ = *parsed_value;
     }
-    if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch", "value_format", "encoding"})) {
-        encoding_ = *parsed_value;
-    }
     if (auto parsed_value = SafeGetFromJsonPath(json_body, {"data_batch", "value"})) {
         decrypted_value_ = *parsed_value;
     }
@@ -426,7 +416,6 @@ bool DecryptJsonResponse::IsValid() const {
            !datatype_.empty() && 
            !compression_.empty() && 
            !format_.empty() && 
-           !encoding_.empty() && 
            !decrypted_value_.empty();
 }
 
@@ -443,7 +432,6 @@ std::string DecryptJsonResponse::GetValidationError() const {
     if (datatype_.empty()) missing_fields.push_back("data_batch.datatype");
     if (compression_.empty()) missing_fields.push_back("data_batch.value_format.compression");
     if (format_.empty()) missing_fields.push_back("data_batch.value_format.format");
-    if (encoding_.empty()) missing_fields.push_back("data_batch.value_format.encoding");
     if (decrypted_value_.empty()) missing_fields.push_back("data_batch.value");
     
     return BuildValidationError(missing_fields);
@@ -460,7 +448,6 @@ std::string DecryptJsonResponse::ToJsonString() const {
     crow::json::wvalue value_format;
     value_format["compression"] = compression_;
     value_format["format"] = format_;
-    value_format["encoding"] = encoding_;
     data_batch["value_format"] = std::move(value_format);
     
     json["data_batch"] = std::move(data_batch);

--- a/src/common/json_request.h
+++ b/src/common/json_request.h
@@ -16,7 +16,6 @@ public:
     std::string datatype_;
     std::string compression_;
     std::string format_;
-    std::string encoding_;
     std::string encrypted_compression_;
     std::string key_id_;
     std::string user_id_;
@@ -259,7 +258,6 @@ public:
     std::string datatype_;
     std::string compression_;
     std::string format_;
-    std::string encoding_;
     std::string decrypted_value_;
     
     /**

--- a/src/common/json_request_test.cpp
+++ b/src/common/json_request_test.cpp
@@ -53,11 +53,10 @@ const std::string VALID_ENCRYPT_JSON = R"({
     },
     "data_batch": {
         "datatype": "BYTE_ARRAY",
-        "value": "test@example.com",
+        "value": "dGVzdEBleGFtcGxlLmNvbQ==",
         "value_format": {
             "compression": "UNCOMPRESSED",
-            "format": "CSV",
-            "encoding": "UTF8"
+            "format": "CSV"
         }
     },
     "data_batch_encrypted": {
@@ -72,7 +71,8 @@ const std::string VALID_ENCRYPT_JSON = R"({
         "user_id": "user456"
     },
     "debug": {
-        "reference_id": "ref789"
+        "reference_id": "ref789",
+        "pretty_printed_value": "test@example.com"
     }
 })";
 
@@ -84,12 +84,11 @@ const std::string VALID_DECRYPT_JSON = R"({
         "datatype": "BYTE_ARRAY",
         "value_format": {
             "compression": "UNCOMPRESSED",
-            "format": "CSV",
-            "encoding": "UTF8"
+            "format": "CSV"
         }
     },
     "data_batch_encrypted": {
-        "value": "ENCRYPTED_test@example.com",
+        "value": "RU5DUllQVEVEX3Rlc3RAZXhhbXBsZS5jb20=",
         "value_format": {
             "compression": "GZIP"
         }
@@ -101,7 +100,8 @@ const std::string VALID_DECRYPT_JSON = R"({
         "user_id": "user456"
     },
     "debug": {
-        "reference_id": "ref789"
+        "reference_id": "ref789",
+        "pretty_printed_value": "ENCRYPTED_test@example.com"
     }
 })";
 
@@ -114,14 +114,13 @@ TEST(JsonRequestValidParse) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
     ASSERT_EQ("ref789", request.reference_id_);
     
     // Check encrypt-specific field
-    ASSERT_EQ("test@example.com", request.value_);
+    ASSERT_EQ("dGVzdEBleGFtcGxlLmNvbQ==", request.value_); // "test@example.com"
     
     ASSERT_TRUE(request.IsValid());
     ASSERT_EQ("", request.GetValidationError());
@@ -141,7 +140,6 @@ TEST(JsonRequestMissingRequiredFields) {
     ASSERT_EQ("", request.datatype_);
     ASSERT_EQ("", request.compression_);
     ASSERT_EQ("", request.format_);
-    ASSERT_EQ("", request.encoding_);
     ASSERT_EQ("", request.encrypted_compression_);
     ASSERT_EQ("", request.key_id_);
     ASSERT_EQ("", request.user_id_);
@@ -165,7 +163,6 @@ TEST(JsonRequestInvalidJson) {
     ASSERT_EQ("", request.datatype_);
     ASSERT_EQ("", request.compression_);
     ASSERT_EQ("", request.format_);
-    ASSERT_EQ("", request.encoding_);
     ASSERT_EQ("", request.encrypted_compression_);
     ASSERT_EQ("", request.key_id_);
     ASSERT_EQ("", request.user_id_);
@@ -183,8 +180,7 @@ TEST(JsonRequestRequiredReferenceIdMissing) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "CSV",
-                "encoding": "UTF8"
+                "format": "CSV"
             }
         },
         "data_batch_encrypted": {
@@ -207,7 +203,6 @@ TEST(JsonRequestRequiredReferenceIdMissing) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
@@ -231,14 +226,13 @@ TEST(EncryptJsonRequestValidParse) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
     ASSERT_EQ("ref789", request.reference_id_);
     
     // Check encrypt-specific fields
-    ASSERT_EQ("test@example.com", request.value_);
+    ASSERT_EQ("dGVzdEBleGFtcGxlLmNvbQ==", request.value_); // "test@example.com"
     
     ASSERT_TRUE(request.IsValid());
     ASSERT_EQ("", request.GetValidationError());
@@ -253,8 +247,7 @@ TEST(EncryptJsonRequestMissingValue) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "CSV",
-                "encoding": "UTF8"
+                "format": "CSV"
             }
         },
         "data_batch_encrypted": {
@@ -269,7 +262,8 @@ TEST(EncryptJsonRequestMissingValue) {
             "user_id": "user456"
         },
         "debug": {
-            "reference_id": "ref789"
+            "reference_id": "ref789",
+            "encrypted_value_plaintext": "ENCRYPTED_test@example.com"
         }
     })";
     
@@ -281,7 +275,6 @@ TEST(EncryptJsonRequestMissingValue) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
@@ -305,14 +298,13 @@ TEST(DecryptJsonRequestValidParse) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
     ASSERT_EQ("ref789", request.reference_id_);
     
     // Check decrypt-specific fields
-    ASSERT_EQ("ENCRYPTED_test@example.com", request.encrypted_value_);
+    ASSERT_EQ("RU5DUllQVEVEX3Rlc3RAZXhhbXBsZS5jb20=", request.encrypted_value_); // "ENCRYPTED_test@example.com"
     
     ASSERT_TRUE(request.IsValid());
     ASSERT_EQ("", request.GetValidationError());
@@ -327,8 +319,7 @@ TEST(DecryptJsonRequestMissingEncryptedValue) {
             "datatype": "BYTE_ARRAY",
             "value_format": {
                 "compression": "UNCOMPRESSED",
-                "format": "CSV",
-                "encoding": "UTF8"
+                "format": "CSV"
             }
         },
         "data_batch_encrypted": {
@@ -343,7 +334,8 @@ TEST(DecryptJsonRequestMissingEncryptedValue) {
             "user_id": "user456"
         },
         "debug": {
-            "reference_id": "ref789"
+            "reference_id": "ref789",
+            "encrypted_value_plaintext": "ENCRYPTED_test@example.com"
         }
     })";
     
@@ -355,7 +347,6 @@ TEST(DecryptJsonRequestMissingEncryptedValue) {
     ASSERT_EQ("BYTE_ARRAY", request.datatype_);
     ASSERT_EQ("UNCOMPRESSED", request.compression_);
     ASSERT_EQ("CSV", request.format_);
-    ASSERT_EQ("UTF8", request.encoding_);
     ASSERT_EQ("GZIP", request.encrypted_compression_);
     ASSERT_EQ("key123", request.key_id_);
     ASSERT_EQ("user456", request.user_id_);
@@ -380,7 +371,7 @@ TEST(SafeGetFromJsonPathValid) {
     
     result = SafeGetFromJsonPath(json_body, {"data_batch", "value"});
     ASSERT_TRUE(result.has_value());
-    ASSERT_EQ("test@example.com", *result);
+    ASSERT_EQ("dGVzdEBleGFtcGxlLmNvbQ==", *result); // "test@example.com"
 }
 
 TEST(SafeGetFromJsonPathInvalidPath) {
@@ -406,7 +397,7 @@ TEST(EncryptJsonRequestToJson) {
     
     // Verify the generated JSON contains expected fields
     ASSERT_TRUE(json_string.find("email") != std::string::npos);
-    ASSERT_TRUE(json_string.find("test@example.com") != std::string::npos);
+    ASSERT_TRUE(json_string.find("dGVzdEBleGFtcGxlLmNvbQ==") != std::string::npos); // "test@example.com"
     ASSERT_TRUE(json_string.find("ref789") != std::string::npos);
     ASSERT_TRUE(json_string.find("key123") != std::string::npos);
     ASSERT_TRUE(json_string.find("user456") != std::string::npos);
@@ -423,7 +414,7 @@ TEST(DecryptJsonRequestToJson) {
     
     // Verify the generated JSON contains expected fields
     ASSERT_TRUE(json_string.find("email") != std::string::npos);
-    ASSERT_TRUE(json_string.find("ENCRYPTED_test@example.com") != std::string::npos);
+    ASSERT_TRUE(json_string.find("RU5DUllQVEVEX3Rlc3RAZXhhbXBsZS5jb20=") != std::string::npos); // "ENCRYPTED_test@example.com"
     ASSERT_TRUE(json_string.find("ref789") != std::string::npos);
     ASSERT_TRUE(json_string.find("key123") != std::string::npos);
     ASSERT_TRUE(json_string.find("user456") != std::string::npos);
@@ -435,7 +426,7 @@ const std::string VALID_ENCRYPT_RESPONSE_JSON = R"({
         "value_format": {
             "compression": "GZIP"
         },
-        "value": "ENCRYPTED_test@example.com"
+        "value": "RU5DUllQVEVEX3Rlc3RAZXhhbXBsZS5jb20="
     },
     "access": {
         "user_id": "user456",
@@ -443,18 +434,18 @@ const std::string VALID_ENCRYPT_RESPONSE_JSON = R"({
         "access_control": "read_write"
     },
     "debug": {
-        "reference_id": "ref789"
+        "reference_id": "ref789",
+        "pretty_printed_value": "ENCRYPTED_test@example.com"
     }
 })";
 
 const std::string VALID_DECRYPT_RESPONSE_JSON = R"({
     "data_batch": {
         "datatype": "BYTE_ARRAY",
-        "value": "test@example.com",
+        "value": "dGVzdEBleGFtcGxlLmNvbQ==",
         "value_format": {
             "compression": "UNCOMPRESSED",
-            "format": "CSV",
-            "encoding": "UTF8"
+            "format": "CSV"
         }
     },
     "access": {
@@ -463,7 +454,8 @@ const std::string VALID_DECRYPT_RESPONSE_JSON = R"({
         "access_control": "read_write"
     },
     "debug": {
-        "reference_id": "ref789"
+        "reference_id": "ref789",
+        "pretty_printed_value": "test@example.com"
     }
 })";
 
@@ -477,7 +469,7 @@ TEST(EncryptJsonResponseValidParse) {
     ASSERT_EQ("read_write", response.access_control_);
     ASSERT_EQ("ref789", response.reference_id_);
     ASSERT_EQ("GZIP", response.encrypted_compression_);
-    ASSERT_EQ("ENCRYPTED_test@example.com", response.encrypted_value_);
+    ASSERT_EQ("RU5DUllQVEVEX3Rlc3RAZXhhbXBsZS5jb20=", response.encrypted_value_); // "ENCRYPTED_test@example.com"
     
     ASSERT_TRUE(response.IsValid());
     ASSERT_EQ("", response.GetValidationError());
@@ -494,8 +486,7 @@ TEST(DecryptJsonResponseValidParse) {
     ASSERT_EQ("BYTE_ARRAY", response.datatype_);
     ASSERT_EQ("UNCOMPRESSED", response.compression_);
     ASSERT_EQ("CSV", response.format_);
-    ASSERT_EQ("UTF8", response.encoding_);
-    ASSERT_EQ("test@example.com", response.decrypted_value_);
+    ASSERT_EQ("dGVzdEBleGFtcGxlLmNvbQ==", response.decrypted_value_); // "test@example.com"
     
     ASSERT_TRUE(response.IsValid());
     ASSERT_EQ("", response.GetValidationError());
@@ -541,7 +532,7 @@ TEST(DecryptJsonResponseMissingDecryptedValue) {
         "debug": {"reference_id": "ref456"},
         "data_batch": {
             "datatype": "BYTE_ARRAY",
-            "value_format": {"compression": "UNCOMPRESSED", "format": "CSV", "encoding": "UTF8"}
+            "value_format": {"compression": "UNCOMPRESSED", "format": "CSV"}
         }
     })");
     
@@ -554,7 +545,7 @@ TEST(EncryptJsonResponseMissingEncryptedCompression) {
     response.Parse(R"({
         "access": {"user_id": "user123", "role": "admin", "access_control": "read"},
         "debug": {"reference_id": "ref456"},
-        "data_batch_encrypted": {"value": "ENCRYPTED_data"}
+        "data_batch_encrypted": {"value": "RU5DUllQVEVEX2RhdGE="} // "ENCRYPTED_data"
     })");
     
     ASSERT_FALSE(response.IsValid());
@@ -563,12 +554,13 @@ TEST(EncryptJsonResponseMissingEncryptedCompression) {
 
 TEST(DecryptJsonResponseMissingDatatype) {
     DecryptJsonResponse response;
+    // value is "decrypted_data"
     response.Parse(R"({
         "access": {"user_id": "user123", "role": "admin", "access_control": "read"},
         "debug": {"reference_id": "ref456"},
         "data_batch": {
-            "value": "decrypted_data",
-            "value_format": {"compression": "UNCOMPRESSED", "format": "CSV", "encoding": "UTF8"}
+            "value": "ZGVjcnlwdGVkX2RhdGE=",
+            "value_format": {"compression": "UNCOMPRESSED", "format": "CSV"}
         }
     })");
     
@@ -583,7 +575,7 @@ TEST(EncryptJsonResponseToJson) {
     response.access_control_ = "read_write";
     response.reference_id_ = "ref456";
     response.encrypted_compression_ = "GZIP";
-    response.encrypted_value_ = "ENCRYPTED_data";
+    response.encrypted_value_ = "RU5DUllQVEVEX2RhdGE="; // "ENCRYPTED_data"
     
     ASSERT_TRUE(response.IsValid());
     
@@ -592,7 +584,7 @@ TEST(EncryptJsonResponseToJson) {
     ASSERT_TRUE(json_string.find("admin") != std::string::npos);
     ASSERT_TRUE(json_string.find("read_write") != std::string::npos);
     ASSERT_TRUE(json_string.find("ref456") != std::string::npos);
-    ASSERT_TRUE(json_string.find("ENCRYPTED_data") != std::string::npos);
+    ASSERT_TRUE(json_string.find("RU5DUllQVEVEX2RhdGE=") != std::string::npos); // "ENCRYPTED_data"
     ASSERT_TRUE(json_string.find("GZIP") != std::string::npos);
 }
 
@@ -605,8 +597,7 @@ TEST(DecryptJsonResponseToJson) {
     response.datatype_ = "BYTE_ARRAY";
     response.compression_ = "UNCOMPRESSED";
     response.format_ = "CSV";
-    response.encoding_ = "UTF8";
-    response.decrypted_value_ = "decrypted_data";
+    response.decrypted_value_ = "ZGVjcnlwdGVkX2RhdGE="; // "decrypted_data"
     
     ASSERT_TRUE(response.IsValid());
     
@@ -615,23 +606,23 @@ TEST(DecryptJsonResponseToJson) {
     ASSERT_TRUE(json_string.find("admin") != std::string::npos);
     ASSERT_TRUE(json_string.find("read_write") != std::string::npos);
     ASSERT_TRUE(json_string.find("ref456") != std::string::npos);
-    ASSERT_TRUE(json_string.find("decrypted_data") != std::string::npos);
+    ASSERT_TRUE(json_string.find("ZGVjcnlwdGVkX2RhdGE=") != std::string::npos); // "decrypted_data"
     ASSERT_TRUE(json_string.find("BYTE_ARRAY") != std::string::npos);
     ASSERT_TRUE(json_string.find("UNCOMPRESSED") != std::string::npos);
     ASSERT_TRUE(json_string.find("CSV") != std::string::npos);
-    ASSERT_TRUE(json_string.find("UTF8") != std::string::npos);
 }
 
 TEST(JsonResponsePartialParsing) {
     EncryptJsonResponse response;
+    // value is "ENCRYPTED_data"
     response.Parse(R"({
         "access": {"user_id": "user123"},
-        "data_batch_encrypted": {"value": "ENCRYPTED_data"}
+        "data_batch_encrypted": {"value": "RU5DUllQVEVEX2RhdGE="}
     })");
     
     // Should parse what it can, but validation should fail
     ASSERT_EQ("user123", response.user_id_);
-    ASSERT_EQ("ENCRYPTED_data", response.encrypted_value_);
+    ASSERT_EQ("RU5DUllQVEVEX2RhdGE=", response.encrypted_value_); // "ENCRYPTED_data"
     ASSERT_FALSE(response.IsValid()); // Missing other required fields
 }
 

--- a/src/common/swagger.yaml
+++ b/src/common/swagger.yaml
@@ -54,7 +54,6 @@ paths:
                     value_format:
                       compression: UNCOMPRESSED
                       format: RAW_C_DATA
-                      encoding: BASE64
                     value: dXNlcjFAZXhhbXBsZS5jb20KdXNlcjJAZXhhbXBsZS5jb20K
                   data_batch_encrypted:
                     value_format:
@@ -78,20 +77,20 @@ paths:
                     pretty_printed_value: "user1@example.com\nuser2@example.com"
                     reference_id: 550e8400-e29b-41d4-a716-446655440000
               ints_csv_utf8:
-                summary: Encrypt CSV of INT32 IDs (UTF-8, uncompressed)
+                summary: Encrypt CSV of INT32 IDs (BASE64 encoded)
                 description: |
-                  Three INT32 values provided as a CSV string. The plaintext is UTF-8 (not base64).
+                  Three INT32 values provided as a CSV string, BASE64 encoded.
+                  Original value: "3344,5566,7788" -> BASE64: "MzM0NCw1NTY2LDc3ODg="
                   Encrypted output will be returned in `data_batch_encrypted.value`.
                 value:
                   column_reference:
                     name: CustomerID
                   data_batch:
-                    value: "3344,5566,7788"
+                    value: "MzM0NCw1NTY2LDc3ODg="
                     datatype: INT32
                     value_format:
                       compression: UNCOMPRESSED
                       format: CSV
-                      encoding: UTF8
                   data_batch_encrypted:
                     value_format:
                       compression: ZSTD
@@ -230,7 +229,6 @@ paths:
                     value_format:
                       compression: UNCOMPRESSED
                       format: RAW_C_DATA
-                      encoding: BASE64
                   encryption:
                     key_id: EMAIL_KEY_001
                   access:
@@ -249,10 +247,10 @@ paths:
                   debug:
                     reference_id: de305d54-75b4-431b-adb2-eb6b9e546014
               ints_csv_utf8:
-                summary: Decrypt CSV of INT32 IDs (UTF-8, uncompressed)
+                summary: Decrypt CSV of INT32 IDs (BASE64 encoded)
                 description: |
-                  Takes an encrypted Base64 blob and decrypts it back into the plaintext CSV
-                  "3344,5566,7788" as UTF-8 text.
+                  Takes an encrypted Base64 blob and decrypts it back into the BASE64 encoded CSV.
+                  Original value: "3344,5566,7788" -> BASE64: "MzM0NCw1NTY2LDc3ODg="
                 value:
                   column_reference:
                     name: CustomerID
@@ -265,7 +263,6 @@ paths:
                     value_format:
                       compression: UNCOMPRESSED
                       format: CSV
-                      encoding: UTF8
                   encryption:
                     key_id: NumericID001
                   access:
@@ -303,7 +300,6 @@ paths:
                       value_format:
                         compression: UNCOMPRESSED
                         format: RAW_C_DATA
-                        encoding: BASE64
                       value: dXNlcjFAZXhhbXBsZS5jb20KdXNlcjJAZXhhbXBsZS5jb20K
                     access:
                       user_id: user123
@@ -315,15 +311,15 @@ paths:
                 ints_csv_utf8_success:
                   summary: Decrypted INT32 CSV IDs
                   description: |
-                    Decrypted back into the original UTF-8 CSV string "3344,5566,7788".
+                    Decrypted back into the BASE64 encoded CSV string.
+                    Original value: "3344,5566,7788" -> BASE64: "MzM0NCw1NTY2LDc3ODg="
                   value:
                     data_batch:
                       datatype: INT32
                       value_format:
                         compression: UNCOMPRESSED
                         format: CSV
-                        encoding: UTF8
-                      value: "3344,5566,7788"
+                      value: "MzM0NCw1NTY2LDc3ODg="
                     access:
                       user_id: GRM_009
                       role: IDReader
@@ -449,27 +445,17 @@ components:
         - RAW_C_DATA
       description: Format used for serializing the data
 
-    encoding:
-      type: string
-      enum:
-        - UTF8
-        - BASE64
-      description: Encoding applied to the data
-
     value_format:
       type: object
       description: Details on how the data was serialized for plaintext values.
       required:
         - compression
         - format
-        - encoding
       properties:
         compression:
           $ref: '#/components/schemas/compression'
         format:
           $ref: '#/components/schemas/serialization_format'
-        encoding:
-          $ref: '#/components/schemas/encoding'
 
     value_format_encrypted:
       type: object

--- a/src/server/dbps_api_server.cpp
+++ b/src/server/dbps_api_server.cpp
@@ -55,7 +55,6 @@ int main() {
             request.datatype_,
             request.compression_,
             request.format_,
-            request.encoding_,
             request.encrypted_compression_,
             request.key_id_
         );
@@ -99,14 +98,12 @@ int main() {
         response.datatype_ = request.datatype_;
         response.compression_ = request.compression_;
         response.format_ = request.format_;
-        response.encoding_ = request.encoding_;
         
         // Use DataBatchEncryptionSequencer for actual decryption
         DataBatchEncryptionSequencer sequencer(
             request.datatype_,
             request.compression_,
             request.format_,
-            request.encoding_,
             request.encrypted_compression_,
             request.key_id_
         );

--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -10,13 +10,11 @@ DataBatchEncryptionSequencer::DataBatchEncryptionSequencer(
     const std::string& datatype,
     const std::string& compression,
     const std::string& format,
-    const std::string& encoding,
     const std::string& encrypted_compression,
     const std::string& key_id
 ) : datatype_(datatype),
     compression_(compression),
     format_(format),
-    encoding_(encoding),
     encrypted_compression_(encrypted_compression),
     key_id_(key_id) {}
 
@@ -152,15 +150,6 @@ bool DataBatchEncryptionSequencer::ConvertStringsToEnums() {
     }
     format_enum_ = *format_result;
     
-    // Convert encoding string to enum
-    auto encoding_result = dbps::enum_utils::to_encoding_enum(encoding_);
-    if (!encoding_result) {
-        error_stage_ = "encoding_conversion";
-        error_message_ = "Invalid encoding: " + encoding_;
-        return false;
-    }
-    encoding_enum_ = *encoding_result;
-    
     return true;
 }
 
@@ -187,13 +176,6 @@ bool DataBatchEncryptionSequencer::ValidateParameters() {
     if (CHECK_COMPRESSION_ENUM && encrypted_compression_enum_ != dbps::external::CompressionCodec::UNCOMPRESSED) {
         std::cerr << "WARNING: Non-UNCOMPRESSED encrypted_compression requested: " << encrypted_compression_ 
                   << ". Only UNCOMPRESSED is currently implemented, proceeding anyway." << std::endl;
-    }
-    
-    // Check encoding: must be BASE64
-    if (encoding_enum_ != dbps::external::Encoding::BASE64) {
-        error_stage_ = "parameter_validation";
-        error_message_ = "Only BASE64 encoding is supported";
-        return false;
     }
     
     // Check format: must be RAW_C_DATA

--- a/src/server/encryption_sequencer.h
+++ b/src/server/encryption_sequencer.h
@@ -16,7 +16,6 @@
  * 
  * Currently supports only:
  * - Compression: UNCOMPRESSED
- * - Encoding: BASE64  
  * - Format: RAW_C_DATA
  * 
  * The class takes constructor parameters that were previously public attributes in JsonRequest.
@@ -26,7 +25,6 @@ public:
     std::string datatype_;
     std::string compression_;
     std::string format_;
-    std::string encoding_;
     std::string encrypted_compression_;
     std::string key_id_;
     
@@ -43,7 +41,6 @@ public:
         const std::string& datatype,
         const std::string& compression,
         const std::string& format,
-        const std::string& encoding,
         const std::string& encrypted_compression,
         const std::string& key_id
     );
@@ -67,7 +64,6 @@ private:
     dbps::external::CompressionCodec::type compression_enum_;
     dbps::external::CompressionCodec::type encrypted_compression_enum_;
     dbps::external::Format::type format_enum_;
-    dbps::external::Encoding::type encoding_enum_;
     
     /**
      * Converts string values to corresponding enum values using enum_utils.
@@ -79,7 +75,7 @@ private:
     /**
      * Performs comprehensive validation of all parameters and key_id.
      * Converts string parameters to enums, validates key_id, and checks supported combinations.
-     * Currently only supports: uncompressed, encoding=base64, format=raw_c_data
+     * Currently only supports: uncompressed, format=raw_c_data
      * Returns true if all validation passes, false otherwise.
      */
     bool ValidateParameters();

--- a/src/server/encryption_sequencer_test.cpp
+++ b/src/server/encryption_sequencer_test.cpp
@@ -16,7 +16,6 @@ bool TestEncryptionDecryption() {
             "BYTE_ARRAY",      // datatype
             "UNCOMPRESSED",    // compression
             "RAW_C_DATA",      // format
-            "BASE64",          // encoding
             "UNCOMPRESSED",    // encrypted_compression
             "test_key_123"     // key_id
         );
@@ -35,11 +34,11 @@ bool TestEncryptionDecryption() {
     // Test 2: Different key_id produces different encryption
     {
         DataBatchEncryptionSequencer sequencer1(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "key1"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "key1"
         );
         
         DataBatchEncryptionSequencer sequencer2(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "key2"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "key2"
         );
         
         std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
@@ -56,11 +55,11 @@ bool TestEncryptionDecryption() {
     // Test 3: Same key_id produces consistent encryption
     {
         DataBatchEncryptionSequencer sequencer1(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "same_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "same_key"
         );
         
         DataBatchEncryptionSequencer sequencer2(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "same_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "same_key"
         );
         
         std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
@@ -77,7 +76,7 @@ bool TestEncryptionDecryption() {
     // Test 4: Empty data encryption
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         
         // This should fail because empty input is rejected
@@ -91,7 +90,7 @@ bool TestEncryptionDecryption() {
     // Test 5: Binary data encryption
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         
         // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
@@ -109,10 +108,10 @@ bool TestEncryptionDecryption() {
 
 // Test parameter validation
 bool TestParameterValidation() {
-    // Test 1: Valid parameters
+    // Test 1: Valid parameters, should succeed
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (!result) {
@@ -124,7 +123,7 @@ bool TestParameterValidation() {
     // Test 2: Invalid compression (should now succeed with warning)
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "GZIP", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "GZIP", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (!result) {
@@ -138,26 +137,10 @@ bool TestParameterValidation() {
         }
     }
     
-    // Test 3: Invalid encoding
+    // Test 3: Invalid format
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UTF8", "UNCOMPRESSED", "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
-        if (result) {
-            std::cout << "Invalid encoding test should have failed" << std::endl;
-            return false;
-        }
-        if (sequencer.error_stage_ != "parameter_validation") {
-            std::cout << "Wrong error stage for invalid encoding: " << sequencer.error_stage_ << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 4: Invalid format
-    {
-        DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "JSON", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "JSON", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (result) {
@@ -178,7 +161,7 @@ bool TestInputValidation() {
     // Test 1: Empty plaintext
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("");
         if (result) {
@@ -194,7 +177,7 @@ bool TestInputValidation() {
     // Test 2: Empty ciphertext
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndDecrypt("");
         if (result) {
@@ -210,7 +193,7 @@ bool TestInputValidation() {
     // Test 3: Empty key_id
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", ""
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", ""
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (result) {
@@ -231,7 +214,7 @@ bool TestEnumConversion() {
     // Test 1: Valid enum conversion
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (!result) {
@@ -243,7 +226,7 @@ bool TestEnumConversion() {
     // Test 2: Invalid datatype
     {
         DataBatchEncryptionSequencer sequencer(
-            "INVALID_TYPE", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "INVALID_TYPE", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (result) {
@@ -264,7 +247,7 @@ bool TestBase64Decoding() {
     // Test 1: Valid base64 - "Hello, World!"
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
         if (!result) {
@@ -276,7 +259,7 @@ bool TestBase64Decoding() {
     // Test 2: Valid base64 - empty string
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("");
         if (result) {
@@ -288,7 +271,7 @@ bool TestBase64Decoding() {
     // Test 3: Valid base64 - single character
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("QQ=="); // "A"
         if (!result) {
@@ -300,7 +283,7 @@ bool TestBase64Decoding() {
     // Test 4: Valid base64 - binary data
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("AAECAwQF"); // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
         if (!result) {
@@ -312,7 +295,7 @@ bool TestBase64Decoding() {
     // Test 5: Invalid base64 - garbage characters
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("InvalidBase64!@#");
         if (result) {
@@ -328,7 +311,7 @@ bool TestBase64Decoding() {
     // Test 6: Invalid base64 - incomplete padding
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ"); // Missing padding
         if (result) {
@@ -349,7 +332,7 @@ bool TestRoundTripEncryption() {
     // Test 1: Basic round trip - "Hello, World!"
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key_123"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key_123"
         );
         
         std::string original_base64 = "SGVsbG8sIFdvcmxkIQ=="; // "Hello, World!"
@@ -380,7 +363,7 @@ bool TestRoundTripEncryption() {
     // Test 2: Binary data round trip
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "binary_test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "binary_test_key"
         );
         
         std::string original_base64 = "AAECAwQF"; // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
@@ -411,7 +394,7 @@ bool TestRoundTripEncryption() {
     // Test 3: Single character round trip
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "single_char_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "single_char_key"
         );
         
         std::string original_base64 = "QQ=="; // "A"
@@ -442,11 +425,11 @@ bool TestRoundTripEncryption() {
     // Test 4: Different keys produce different encrypted results
     {
         DataBatchEncryptionSequencer sequencer1(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "key1"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "key1"
         );
         
         DataBatchEncryptionSequencer sequencer2(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "key2"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "key2"
         );
         
         std::string original_base64 = "SGVsbG8sIFdvcmxkIQ==";
@@ -488,7 +471,7 @@ bool TestResultStorage() {
     // Test 1: Verify encrypted result is stored
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         
         std::string original_base64 = "SGVsbG8sIFdvcmxkIQ==";
@@ -520,7 +503,7 @@ bool TestResultStorage() {
     // Test 2: Verify decrypted result is stored
     {
         DataBatchEncryptionSequencer sequencer(
-            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "BASE64", "UNCOMPRESSED", "test_key"
+            "BYTE_ARRAY", "UNCOMPRESSED", "RAW_C_DATA", "UNCOMPRESSED", "test_key"
         );
         
         // First encrypt something
@@ -565,23 +548,23 @@ int main() {
     all_tests_passed &= TestParameterValidation();
     PrintTestResult("Parameter Validation", all_tests_passed);
     
-    all_tests_passed &= TestInputValidation();
-    PrintTestResult("Input Validation", all_tests_passed);
+    // all_tests_passed &= TestInputValidation();
+    // PrintTestResult("Input Validation", all_tests_passed);
     
-    all_tests_passed &= TestEnumConversion();
-    PrintTestResult("Enum Conversion", all_tests_passed);
+    // all_tests_passed &= TestEnumConversion();
+    // PrintTestResult("Enum Conversion", all_tests_passed);
     
-    all_tests_passed &= TestBase64Decoding();
-    PrintTestResult("Base64 Decoding", all_tests_passed);
+    // all_tests_passed &= TestBase64Decoding();
+    // PrintTestResult("Base64 Decoding", all_tests_passed);
     
-    all_tests_passed &= TestEncryptionDecryption();
-    PrintTestResult("Encryption/Decryption", all_tests_passed);
+    // all_tests_passed &= TestEncryptionDecryption();
+    // PrintTestResult("Encryption/Decryption", all_tests_passed);
     
-    all_tests_passed &= TestRoundTripEncryption();
-    PrintTestResult("Round-Trip Encryption", all_tests_passed);
+    // all_tests_passed &= TestRoundTripEncryption();
+    // PrintTestResult("Round-Trip Encryption", all_tests_passed);
     
-    all_tests_passed &= TestResultStorage();
-    PrintTestResult("Result Storage", all_tests_passed);
+    // all_tests_passed &= TestResultStorage();
+    // PrintTestResult("Result Storage", all_tests_passed);
     
     std::cout << "=============================================" << std::endl;
     if (all_tests_passed) {

--- a/src/server/encryption_sequencer_test.cpp
+++ b/src/server/encryption_sequencer_test.cpp
@@ -548,23 +548,23 @@ int main() {
     all_tests_passed &= TestParameterValidation();
     PrintTestResult("Parameter Validation", all_tests_passed);
     
-    // all_tests_passed &= TestInputValidation();
-    // PrintTestResult("Input Validation", all_tests_passed);
+    all_tests_passed &= TestInputValidation();
+    PrintTestResult("Input Validation", all_tests_passed);
     
-    // all_tests_passed &= TestEnumConversion();
-    // PrintTestResult("Enum Conversion", all_tests_passed);
+    all_tests_passed &= TestEnumConversion();
+    PrintTestResult("Enum Conversion", all_tests_passed);
     
-    // all_tests_passed &= TestBase64Decoding();
-    // PrintTestResult("Base64 Decoding", all_tests_passed);
+    all_tests_passed &= TestBase64Decoding();
+    PrintTestResult("Base64 Decoding", all_tests_passed);
     
-    // all_tests_passed &= TestEncryptionDecryption();
-    // PrintTestResult("Encryption/Decryption", all_tests_passed);
+    all_tests_passed &= TestEncryptionDecryption();
+    PrintTestResult("Encryption/Decryption", all_tests_passed);
     
-    // all_tests_passed &= TestRoundTripEncryption();
-    // PrintTestResult("Round-Trip Encryption", all_tests_passed);
+    all_tests_passed &= TestRoundTripEncryption();
+    PrintTestResult("Round-Trip Encryption", all_tests_passed);
     
-    // all_tests_passed &= TestResultStorage();
-    // PrintTestResult("Result Storage", all_tests_passed);
+    all_tests_passed &= TestResultStorage();
+    PrintTestResult("Result Storage", all_tests_passed);
     
     std::cout << "=============================================" << std::endl;
     if (all_tests_passed) {


### PR DESCRIPTION
- First step to adding more formats to payloads.
- Removing encoding field from swagger.yaml and related code
- All payloads are now BASE64 encoded (transport encoding)