### PR TITLE
Update API server utils to strip level bytes from payload before byte de-encoding

### DIFF
--- a/src/server/decoding_utils.h
+++ b/src/server/decoding_utils.h
@@ -22,10 +22,10 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
 
     // Validate leading_bytes_to_strip parameter
     if (leading_bytes_to_strip < 0) {
-        return "Invalid leading_bytes_to_strip: must be >= 0";
+        return "Number of leading bytes to strip must be >= 0";
     }
     if (leading_bytes_to_strip > 0 && raw.size() <= leading_bytes_to_strip) {
-        return "Invalid leading_bytes_to_strip: must be < data size";
+        return "Number of leading bytes to strip must be < data size";
     }
 
     // Create adjusted data vector by stripping leading bytes (or use original if 0)
@@ -38,18 +38,18 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
 
     auto require = [&](bool cond) -> bool { return cond; };
 
-    const uint8_t* data = adjusted_raw.data();
-    const uint8_t* end  = data + adjusted_raw.size();
+    const uint8_t* raw_data = adjusted_raw.data();
+    const size_t raw_size = adjusted_raw.size();
 
     std::ostringstream out;
 
     switch (physical_type) {
         case Type::INT32: {
-            if (!require((adjusted_raw.size() % sizeof(int32_t)) == 0))
+            if (!require((raw_size % sizeof(int32_t)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT32 values:\n";
-            const int32_t* v = reinterpret_cast<const int32_t*>(data);
-            size_t count = adjusted_raw.size() / sizeof(int32_t);
+            const int32_t* v = reinterpret_cast<const int32_t*>(raw_data);
+            size_t count = raw_size / sizeof(int32_t);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -57,11 +57,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::INT64: {
-            if (!require((adjusted_raw.size() % sizeof(int64_t)) == 0))
+            if (!require((raw_size % sizeof(int64_t)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT64 values:\n";
-            const int64_t* v = reinterpret_cast<const int64_t*>(data);
-            size_t count = adjusted_raw.size() / sizeof(int64_t);
+            const int64_t* v = reinterpret_cast<const int64_t*>(raw_data);
+            size_t count = raw_size / sizeof(int64_t);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -69,11 +69,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::FLOAT: {
-            if (!require((adjusted_raw.size() % sizeof(float)) == 0))
+            if (!require((raw_size % sizeof(float)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded FLOAT values:\n";
-            const float* v = reinterpret_cast<const float*>(data);
-            size_t count = adjusted_raw.size() / sizeof(float);
+            const float* v = reinterpret_cast<const float*>(raw_data);
+            size_t count = raw_size / sizeof(float);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -81,11 +81,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::DOUBLE: {
-            if (!require((adjusted_raw.size() % sizeof(double)) == 0))
+            if (!require((raw_size % sizeof(double)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded DOUBLE values:\n";
-            const double* v = reinterpret_cast<const double*>(data);
-            size_t count = adjusted_raw.size() / sizeof(double);
+            const double* v = reinterpret_cast<const double*>(raw_data);
+            size_t count = raw_size / sizeof(double);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -93,12 +93,13 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::INT96: {
-            if (!require((adjusted_raw.size() % 12) == 0))
+            if (!require((raw_size % 12) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT96 values ([lo, mid, hi] 32-bit words):\n";
-            const uint8_t* p = data;
+            const uint8_t* p = raw_data;
+            const uint8_t* last_byte = raw_data + raw_size;
             int idx = 0;
-            while (p + 12 <= end) {
+            while (p + 12 <= last_byte) {
                 uint32_t lo, mid, hi;
                 std::memcpy(&lo,  p + 0,  4);  // little-endian assumed
                 std::memcpy(&mid, p + 4,  4);
@@ -111,32 +112,31 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
 
         case Type::BYTE_ARRAY: {
             out << "Decoded BYTE_ARRAY values:\n";
-            const uint8_t* p = data;
+            const uint8_t* p = raw_data;
+            const uint8_t*  last_byte = raw_data + raw_size;
             int idx = 0;
-            while (p + 4 <= end) {
+            while (p + 4 <= last_byte) {
                 uint32_t len;
                 std::memcpy(&len, p, sizeof(len));  // little-endian assumed
                 p += 4;
-                if (!require(p + len <= end)) return DECODE_ERROR_STR;
+                if (!require(p + len <= last_byte)) return DECODE_ERROR_STR;
                 const char* s = reinterpret_cast<const char*>(p);
                 out << "  [" << idx++ << "] \"" << std::string(s, s + len) << "\"\n";
                 p += len;
             }
-            if (!require(p == end)) return DECODE_ERROR_STR;
+            if (!require(p == last_byte)) return DECODE_ERROR_STR;
             break;
         }
 
         case Type::FIXED_LEN_BYTE_ARRAY: {
-            if (!datatype_length.has_value() || datatype_length.value() <= 0 || (adjusted_raw.size() % datatype_length.value()) != 0) {
+            if (!datatype_length.has_value() || datatype_length.value() <= 0 || (raw_size % datatype_length.value()) != 0) {
                 return DECODE_ERROR_STR;
             }
-            
             int fixed_length = datatype_length.value();
-            
             out << "Decoded FIXED_LEN_BYTE_ARRAY (length=" << fixed_length << "):\n";
-            size_t element_count = adjusted_raw.size() / fixed_length;
+            size_t element_count = raw_size / fixed_length;
             for (size_t i = 0; i < element_count; ++i) {
-                const char* element_start = reinterpret_cast<const char*>(data + i * fixed_length);
+                const char* element_start = reinterpret_cast<const char*>(raw_data + i * fixed_length);
                 out << "  [" << i << "] \"" << std::string(element_start, fixed_length) << "\"\n";
             }
             break;
@@ -145,8 +145,8 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         // This is a known type, but passed as "undefined" by the API caller intentionally.
         case Type::UNDEFINED: {
             out << "Decoded UNDEFINED type (raw bytes):\n";
-            const char* s = reinterpret_cast<const char*>(data);
-            out << "  \"" << std::string(s, s + adjusted_raw.size()) << "\"\n";
+            const char* s = reinterpret_cast<const char*>(raw_data);
+            out << "  \"" << std::string(s, s + raw_size) << "\"\n";
             break;
         }
 

--- a/src/server/decoding_utils.h
+++ b/src/server/decoding_utils.h
@@ -13,26 +13,43 @@ using namespace dbps::external;
  * Decodes raw binary data into a human-readable string for debugging/logging.
  * Returns "decode error" on failure or "unsupported type" for unimplemented types.
  * For FIXED_LEN_BYTE_ARRAY, datatype_length specifies the fixed length of each element.
+ * leading_bytes_to_strip specifies the number of bytes to remove from the beginning of raw data.
  */
 std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physical_type,
-    std::optional<int> datatype_length = std::nullopt) {
+    std::optional<int> datatype_length = std::nullopt, int leading_bytes_to_strip = 0) {
     static constexpr const char* DECODE_ERROR_STR = "Unknown encoding";
     static constexpr const char* UNSUPPORTED_TYPE_STR = "Unsupported type";
 
+    // Validate leading_bytes_to_strip parameter
+    if (leading_bytes_to_strip < 0) {
+        return "Invalid leading_bytes_to_strip: must be >= 0";
+    }
+    if (leading_bytes_to_strip > 0 && raw.size() <= leading_bytes_to_strip) {
+        return "Invalid leading_bytes_to_strip: must be < data size";
+    }
+
+    // Create adjusted data vector by stripping leading bytes (or use original if 0)
+    std::vector<uint8_t> adjusted_raw;
+    if (leading_bytes_to_strip == 0) {
+        adjusted_raw = raw;  // No stripping needed
+    } else {
+        adjusted_raw = std::vector<uint8_t>(raw.begin() + leading_bytes_to_strip, raw.end());
+    }
+
     auto require = [&](bool cond) -> bool { return cond; };
 
-    const uint8_t* data = raw.data();
-    const uint8_t* end  = data + raw.size();
+    const uint8_t* data = adjusted_raw.data();
+    const uint8_t* end  = data + adjusted_raw.size();
 
     std::ostringstream out;
 
     switch (physical_type) {
         case Type::INT32: {
-            if (!require((raw.size() % sizeof(int32_t)) == 0))
+            if (!require((adjusted_raw.size() % sizeof(int32_t)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT32 values:\n";
             const int32_t* v = reinterpret_cast<const int32_t*>(data);
-            size_t count = raw.size() / sizeof(int32_t);
+            size_t count = adjusted_raw.size() / sizeof(int32_t);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -40,11 +57,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::INT64: {
-            if (!require((raw.size() % sizeof(int64_t)) == 0))
+            if (!require((adjusted_raw.size() % sizeof(int64_t)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT64 values:\n";
             const int64_t* v = reinterpret_cast<const int64_t*>(data);
-            size_t count = raw.size() / sizeof(int64_t);
+            size_t count = adjusted_raw.size() / sizeof(int64_t);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -52,11 +69,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::FLOAT: {
-            if (!require((raw.size() % sizeof(float)) == 0))
+            if (!require((adjusted_raw.size() % sizeof(float)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded FLOAT values:\n";
             const float* v = reinterpret_cast<const float*>(data);
-            size_t count = raw.size() / sizeof(float);
+            size_t count = adjusted_raw.size() / sizeof(float);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -64,11 +81,11 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::DOUBLE: {
-            if (!require((raw.size() % sizeof(double)) == 0))
+            if (!require((adjusted_raw.size() % sizeof(double)) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded DOUBLE values:\n";
             const double* v = reinterpret_cast<const double*>(data);
-            size_t count = raw.size() / sizeof(double);
+            size_t count = adjusted_raw.size() / sizeof(double);
             for (size_t i = 0; i < count; ++i) { 
                 out << "  [" << i << "] " << v[i] << "\n"; 
             }
@@ -76,7 +93,7 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::INT96: {
-            if (!require((raw.size() % 12) == 0))
+            if (!require((adjusted_raw.size() % 12) == 0))
                 return DECODE_ERROR_STR;
             out << "Decoded INT96 values ([lo, mid, hi] 32-bit words):\n";
             const uint8_t* p = data;
@@ -110,14 +127,14 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         }
 
         case Type::FIXED_LEN_BYTE_ARRAY: {
-            if (!datatype_length.has_value() || datatype_length.value() <= 0 || (raw.size() % datatype_length.value()) != 0) {
+            if (!datatype_length.has_value() || datatype_length.value() <= 0 || (adjusted_raw.size() % datatype_length.value()) != 0) {
                 return DECODE_ERROR_STR;
             }
             
             int fixed_length = datatype_length.value();
             
             out << "Decoded FIXED_LEN_BYTE_ARRAY (length=" << fixed_length << "):\n";
-            size_t element_count = raw.size() / fixed_length;
+            size_t element_count = adjusted_raw.size() / fixed_length;
             for (size_t i = 0; i < element_count; ++i) {
                 const char* element_start = reinterpret_cast<const char*>(data + i * fixed_length);
                 out << "  [" << i << "] \"" << std::string(element_start, fixed_length) << "\"\n";
@@ -129,7 +146,7 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
         case Type::UNDEFINED: {
             out << "Decoded UNDEFINED type (raw bytes):\n";
             const char* s = reinterpret_cast<const char*>(data);
-            out << "  \"" << std::string(s, s + raw.size()) << "\"\n";
+            out << "  \"" << std::string(s, s + adjusted_raw.size()) << "\"\n";
             break;
         }
 

--- a/src/server/decoding_utils_test.cpp
+++ b/src/server/decoding_utils_test.cpp
@@ -133,15 +133,15 @@ static void test_leading_bytes_to_strip_error_cases() {
     
     // Test negative value
     auto s1 = PrintPlainDecoded(buf, Type::INT32, std::nullopt, -1);
-    assert(s1 == std::string("Invalid leading_bytes_to_strip: must be >= 0"));
+    assert(s1 == std::string("Number of leading bytes to strip must be >= 0"));
     
     // Test value larger than data size
     auto s2 = PrintPlainDecoded(buf, Type::INT32, std::nullopt, 20);
-    assert(s2 == std::string("Invalid leading_bytes_to_strip: must be < data size"));
+    assert(s2 == std::string("Number of leading bytes to strip must be < data size"));
     
     // Test value equal to data size (should also fail)
     auto s3 = PrintPlainDecoded(buf, Type::INT32, std::nullopt, 12);
-    assert(s3 == std::string("Invalid leading_bytes_to_strip: must be < data size"));
+    assert(s3 == std::string("Number of leading bytes to strip must be < data size"));
 }
 
 static void test_leading_bytes_to_strip_valid_case() {

--- a/src/server/decoding_utils_test.cpp
+++ b/src/server/decoding_utils_test.cpp
@@ -38,7 +38,7 @@ static void test_INT32_ok() {
     append_le<int32_t>(buf, -2);
     append_le<int32_t>(buf, 123456789);
 
-    auto s = PrintPlainDecoded(buf, Type::INT32, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::INT32);
     assert(contains(s, "[0] 1"));
     assert(contains(s, "[1] -2"));
     assert(contains(s, "[2] 123456789"));
@@ -48,7 +48,7 @@ static void test_INT64_ok() {
     std::vector<uint8_t> buf;
     append_le<int64_t>(buf, 42LL);
     append_le<int64_t>(buf, -99LL);
-    auto s = PrintPlainDecoded(buf, Type::INT64, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::INT64);
     assert(contains(s, "[0] 42"));
     assert(contains(s, "[1] -99"));
 }
@@ -57,7 +57,7 @@ static void test_FLOAT_ok() {
     std::vector<uint8_t> buf;
     append_le<float>(buf, 1.5f);
     append_le<float>(buf, -2.25f);
-    auto s = PrintPlainDecoded(buf, Type::FLOAT, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::FLOAT);
     assert(contains(s, "[0] 1.5"));
     assert(contains(s, "[1] -2.25"));
 }
@@ -66,7 +66,7 @@ static void test_DOUBLE_ok() {
     std::vector<uint8_t> buf;
     append_le<double>(buf, 3.14159);
     append_le<double>(buf, -0.5);
-    auto s = PrintPlainDecoded(buf, Type::DOUBLE, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::DOUBLE);
     assert(contains(s, "[0] 3.14159"));
     assert(contains(s, "[1] -0.5"));
 }
@@ -77,7 +77,7 @@ static void test_INT96_ok() {
     append_le<uint32_t>(buf, 11);
     append_le<uint32_t>(buf, 22);
     append_le<uint32_t>(buf, 33);
-    auto s = PrintPlainDecoded(buf, Type::INT96, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::INT96);
     assert(contains(s, "[0] [11, 22, 33]"));
 }
 
@@ -85,7 +85,7 @@ static void test_BYTE_ARRAY_ok() {
     std::vector<uint8_t> buf;
     append_len_prefixed(buf, "alpha");
     append_len_prefixed(buf, "βeta"); // UTF-8 is fine, treated as bytes
-    auto s = PrintPlainDecoded(buf, Type::BYTE_ARRAY, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::BYTE_ARRAY);
     assert(contains(s, "[0] \"alpha\""));
     assert(contains(s, "[1] \"βeta\""));
 }
@@ -93,7 +93,7 @@ static void test_BYTE_ARRAY_ok() {
 static void test_FIXED_LEN_BYTE_ARRAY_ok() {
     std::string msg = "hello world";
     std::vector<uint8_t> buf(msg.begin(), msg.end());
-    auto s = PrintPlainDecoded(buf, Type::FIXED_LEN_BYTE_ARRAY, 11, 0); // length = 11
+    auto s = PrintPlainDecoded(buf, Type::FIXED_LEN_BYTE_ARRAY, 11); // length = 11
     assert(contains(s, "\"hello world\""));
 }
 
@@ -107,7 +107,7 @@ static void test_FIXED_LEN_BYTE_ARRAY_multiple_elements() {
     buf.insert(buf.end(), elem2.begin(), elem2.end());
     buf.insert(buf.end(), elem3.begin(), elem3.end());
     
-    auto s = PrintPlainDecoded(buf, Type::FIXED_LEN_BYTE_ARRAY, 3, 0); // length = 3
+    auto s = PrintPlainDecoded(buf, Type::FIXED_LEN_BYTE_ARRAY, 3); // length = 3
     assert(contains(s, "[0] \"abc\""));
     assert(contains(s, "[1] \"def\""));
     assert(contains(s, "[2] \"ghi\""));
@@ -115,13 +115,13 @@ static void test_FIXED_LEN_BYTE_ARRAY_multiple_elements() {
 
 static void test_decode_error_misaligned() {
     std::vector<uint8_t> buf = {0x01, 0x02, 0x03}; // 3 bytes, not multiple of 4
-    auto s = PrintPlainDecoded(buf, Type::INT32, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::INT32);
     assert(s == std::string("Unknown encoding"));
 }
 
 static void test_unsupported_type() {
     std::vector<uint8_t> buf; // empty is fine; we just want the type check
-    auto s = PrintPlainDecoded(buf, Type::BOOLEAN, std::nullopt, 0);
+    auto s = PrintPlainDecoded(buf, Type::BOOLEAN);
     assert(s == std::string("Unsupported type"));
 }
 

--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -59,8 +59,11 @@ bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::string& plaintex
                   << decoded_data.size() << " bytes" << std::endl;
     }    
     if (is_uncompressed && is_plain) {
+        // TODO: Pass calculation of level bytes count when passed on the Sequencer constructor.
+        int leading_bytes_to_strip = 0;
+
         // Only show detailed decode output if both UNCOMPRESSED and PLAIN
-        std::string debug_decoded = PrintPlainDecoded(decoded_data, datatype_enum_, datatype_length_);
+        std::string debug_decoded = PrintPlainDecoded(decoded_data, datatype_enum_, datatype_length_, leading_bytes_to_strip);
         if (debug_decoded.length() > 1000) {
             std::cout << "Encrypt value - Decoded plaintext data (first 1000 chars):\n" 
                       << debug_decoded.substr(0, 1000) << "..." << std::endl;


### PR DESCRIPTION
- Update PrintPlainDecoded to strip level bytes from the beginning of the data.
- This PR change the util function.  API server still needs to capture the number of level bytes from the parameter calls (change to come when the updated payload is complete)