### PR TITLE
Adding additional encoding_attributes with the page_level metatada to API server

### DIFF
--- a/src/client/dbps_api_client.cpp
+++ b/src/client/dbps_api_client.cpp
@@ -202,6 +202,7 @@ EncryptApiResponse DBPSApiClient::Encrypt(
     const std::optional<int>& datatype_length,
     CompressionCodec::type compression,
     Format::type format,
+    const std::map<std::string, std::string>& encoding_attributes,
     CompressionCodec::type encrypted_compression,
     const std::string& key_id,
     const std::string& user_id
@@ -212,6 +213,7 @@ EncryptApiResponse DBPSApiClient::Encrypt(
     json_request.datatype_length_ = datatype_length;
     json_request.compression_ = std::string(to_string(compression));
     json_request.format_ = std::string(to_string(format));
+    json_request.encoding_attributes_ = encoding_attributes;
     json_request.encrypted_compression_ = std::string(to_string(encrypted_compression));
     json_request.key_id_ = key_id;
     json_request.user_id_ = user_id;
@@ -281,6 +283,7 @@ DecryptApiResponse DBPSApiClient::Decrypt(
     const std::optional<int>& datatype_length,
     CompressionCodec::type compression,
     Format::type format,
+    const std::map<std::string, std::string>& encoding_attributes,
     CompressionCodec::type encrypted_compression,
     const std::string& key_id,
     const std::string& user_id
@@ -291,6 +294,7 @@ DecryptApiResponse DBPSApiClient::Decrypt(
     json_request.datatype_length_ = datatype_length;
     json_request.compression_ = std::string(to_string(compression));
     json_request.format_ = std::string(to_string(format));
+    json_request.encoding_attributes_ = encoding_attributes;
     json_request.encrypted_compression_ = std::string(to_string(encrypted_compression));
     json_request.key_id_ = key_id;
     json_request.user_id_ = user_id;

--- a/src/client/dbps_api_client.h
+++ b/src/client/dbps_api_client.h
@@ -148,6 +148,7 @@ public:
      * @param datatype The data type of the plaintext (e.g., BYTE_ARRAY, STRING, etc.)
      * @param compression Compression algorithm used to compress the plaintext before this call (format of the input)
      * @param format Data format specification (Parquet formats supported)
+     * @param encoding_attributes Map of string key-value pairs containing encoding-specific attributes
      * @param encrypted_compression Compression algorithm to be used to compress the encrypted data (format of the output)
      * @param key_id Identifier for the encryption key to be used (not the key itself)
      * @param user_id Identifier for the user requesting the encryption
@@ -163,6 +164,7 @@ public:
         const std::optional<int>& datatype_length,
         CompressionCodec::type compression,
         Format::type format,
+        const std::map<std::string, std::string>& encoding_attributes,
         CompressionCodec::type encrypted_compression,
         const std::string& key_id,
         const std::string& user_id
@@ -176,6 +178,7 @@ public:
      * @param datatype The data type of the original plaintext (e.g., BYTE_ARRAY, STRING, etc.)
      * @param compression Compression algorithm used to compress the encrypted data before this call (format of the input)
      * @param format Data format specification (Parquet formats supported)
+     * @param encoding_attributes Map of string key-value pairs containing encoding-specific attributes
      * @param encrypted_compression Compression algorithm to be used to compress the decrypted data (format of the output)
      * @param key_id Identifier for the encryption key to be used for decryption (not the key itself)
      * @param user_id Identifier for the user requesting the decryption
@@ -191,6 +194,7 @@ public:
         const std::optional<int>& datatype_length,
         CompressionCodec::type compression,
         Format::type format,
+        const std::map<std::string, std::string>& encoding_attributes,
         CompressionCodec::type encrypted_compression,
         const std::string& key_id,
         const std::string& user_id

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -368,5 +368,6 @@ std::optional<Format::type> RemoteDataBatchProtectionAgent::ExtractPageEncoding(
         }
     }
     // Return nullopt if page_encoding not found
+    std::cerr << "ERROR: RemoteDataBatchProtectionAgent::ExtractPageEncoding() - page_encoding not found." << std::endl;
     return std::nullopt;
 }

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -232,15 +232,24 @@ std::unique_ptr<EncryptionResult> RemoteDataBatchProtectionAgent::Encrypt(span<c
         return std::make_unique<RemoteEncryptionResult>(std::move(empty_response));
     }
     
+    // Extract page_encoding from encoding_attributes and convert to Format::type
+    auto format_opt = ExtractPageEncoding(encoding_attributes);
+    if (!format_opt.has_value()) {
+        std::cerr << "ERROR: RemoteDataBatchProtectionAgent::Encrypt() - page_encoding not found or invalid in encoding_attributes." << std::endl;
+        auto empty_response = std::make_unique<EncryptApiResponse>();
+        empty_response->SetApiClientError("page_encoding not found or invalid in encoding_attributes");
+        return std::make_unique<RemoteEncryptionResult>(std::move(empty_response));
+    }
+    
     // Make the encryption call to the server
-    // TODO: Update API client to accept encoding_attributes parameter and validate that it contains mandatory fields.
     auto response = api_client_->Encrypt(
         plaintext,
         column_name_,
         datatype_,
         datatype_length_,
         compression_type_,
-        Format::PLAIN,  // Currently only PLAIN is supported
+        format_opt.value(),
+        encoding_attributes,
         compression_type_,
         column_key_id_,
         user_id_
@@ -278,15 +287,24 @@ std::unique_ptr<DecryptionResult> RemoteDataBatchProtectionAgent::Decrypt(span<c
         return std::make_unique<RemoteDecryptionResult>(std::move(empty_response));
     }
     
+    // Extract page_encoding from encoding_attributes and convert to Format::type
+    auto format_opt = ExtractPageEncoding(encoding_attributes);
+    if (!format_opt.has_value()) {
+        std::cerr << "ERROR: RemoteDataBatchProtectionAgent::Decrypt() - page_encoding not found or invalid in encoding_attributes." << std::endl;
+        auto empty_response = std::make_unique<DecryptApiResponse>();
+        empty_response->SetApiClientError("page_encoding not found or invalid in encoding_attributes");
+        return std::make_unique<RemoteDecryptionResult>(std::move(empty_response));
+    }
+    
     // Make the decryption call to the server
-    // TODO: Update API client to accept encoding_attributes parameter and validate that it contains mandatory fields.
     auto response = api_client_->Decrypt(
         ciphertext,
         column_name_,
         datatype_,
         datatype_length_,
         compression_type_,
-        Format::PLAIN,  // Currently only PLAIN is supported
+        format_opt.value(),
+        encoding_attributes,
         compression_type_,
         column_key_id_,
         user_id_
@@ -334,5 +352,21 @@ std::optional<std::string> RemoteDataBatchProtectionAgent::ExtractUserId(const s
     } catch (const nlohmann::json::exception& e) {
         std::cerr << "ERROR: RemoteDataBatchProtectionAgent::ExtractUserId() - Failed to parse app_context JSON: " << e.what() << std::endl;
     }
+    return std::nullopt;
+}
+
+std::optional<Format::type> RemoteDataBatchProtectionAgent::ExtractPageEncoding(const std::map<std::string, std::string>& encoding_attributes) const {
+    auto it = encoding_attributes.find("page_encoding");
+    if (it != encoding_attributes.end()) {
+        const std::string& encoding_str = it->second;
+        auto format_opt = to_format_enum(encoding_str);
+        if (format_opt.has_value()) {
+            return format_opt.value();
+        } else {
+            std::cerr << "ERROR: RemoteDataBatchProtectionAgent::ExtractPageEncoding() - Unknown page_encoding: " << encoding_str << std::endl;
+            return std::nullopt;
+        }
+    }
+    // Return nullopt if page_encoding not found
     return std::nullopt;
 }

--- a/src/common/dbpa_remote.h
+++ b/src/common/dbpa_remote.h
@@ -114,6 +114,7 @@ private:
     // Helper methods for configuration parsing
     std::optional<std::string> ExtractServerUrl(const std::map<std::string, std::string>& connection_config) const;
     std::optional<std::string> ExtractUserId(const std::string& app_context) const;
+    std::optional<Format::type> ExtractPageEncoding(const std::map<std::string, std::string>& encoding_attributes) const;
     
     // Client instance
     std::unique_ptr<DBPSApiClient> api_client_;

--- a/src/common/dbpa_remote_test.cpp
+++ b/src/common/dbpa_remote_test.cpp
@@ -120,7 +120,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, DecryptWithoutInit) {
     
     // Don't call init() - leave agent uninitialized
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Decrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -149,7 +149,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, MissingServerUrl) {
     
     // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Encrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -180,7 +180,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, MissingUserId) {
     
     // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Encrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -213,7 +213,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, HealthCheckFailure) {
     
     // Test that Encrypt() returns a failed result with the initialization error
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Encrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -249,7 +249,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulEncryption) {
                                Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Encrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -290,7 +290,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulDecryption) {
                                Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+    std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
     auto result = agent.Decrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
@@ -359,7 +359,12 @@ TEST_F(RemoteDataBatchProtectionAgentTest, DecryptionFieldMismatch) {
                                    Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
         
         std::vector<uint8_t> test_data = {1, 2, 3, 4};
-        auto result = agent.Decrypt(test_data);
+        std::map<std::string, std::string> encoding_attributes = {
+            {"page_type", "DATA_PAGE"},
+            {"page_encoding", "PLAIN"},
+            {"data_page_num_values", "4"}
+        };
+        auto result = agent.Decrypt(test_data, encoding_attributes);
         
         ASSERT_NE(result, nullptr);
         EXPECT_FALSE(result->success());
@@ -396,7 +401,12 @@ TEST_F(RemoteDataBatchProtectionAgentTest, EncryptionFieldMismatch) {
                                Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
-    auto result = agent.Encrypt(test_data);
+    std::map<std::string, std::string> encoding_attributes = {
+        {"page_type", "DATA_PAGE"},
+        {"page_encoding", "PLAIN"},
+        {"data_page_num_values", "4"}
+    };
+    auto result = agent.Encrypt(test_data, encoding_attributes);
     
     ASSERT_NE(result, nullptr);
     EXPECT_FALSE(result->success());

--- a/src/common/json_request.cpp
+++ b/src/common/json_request.cpp
@@ -104,8 +104,8 @@ void JsonRequest::ParseCommon(const std::string& request_body) {
     if (json_body.has("data_batch") && json_body["data_batch"].has("value_format") && 
         json_body["data_batch"]["value_format"].has("encoding_attributes")) {
         auto attrs_json = json_body["data_batch"]["value_format"]["encoding_attributes"];
+        // Check that attrs_json is not empty and is not an array or literal value
         if (attrs_json && attrs_json.t() == crow::json::type::Object) {
-            encoding_attributes_.clear();
             auto keys = attrs_json.keys();
             for (const auto& key : keys) {
                 encoding_attributes_[key] = std::string(attrs_json[key]);

--- a/src/common/json_request.h
+++ b/src/common/json_request.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include <map>
 
 /**
  * Base class for parsing and validating JSON request fields.
@@ -17,6 +18,7 @@ public:
     std::optional<int> datatype_length_;
     std::string compression_;
     std::string format_;
+    std::map<std::string, std::string> encoding_attributes_;
     std::string encrypted_compression_;
     std::string key_id_;
     std::string user_id_;

--- a/src/scripts/dbpa_remote_testapp.cpp
+++ b/src/scripts/dbpa_remote_testapp.cpp
@@ -163,7 +163,7 @@ public:
                 std::vector<uint8_t> plaintext(original_data.begin(), original_data.end());
                 
                 // First encrypt
-                std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+                std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
                 auto encrypt_result = agent_->Encrypt(span<const uint8_t>(plaintext), encoding_attributes);
                 
                 if (!encrypt_result || !encrypt_result->success()) {
@@ -252,7 +252,7 @@ public:
                 std::vector<uint8_t> plaintext(test_data.begin(), test_data.end());
                 
                 // Encrypt
-                std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+                std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
                 auto encrypt_result = agent_->Encrypt(span<const uint8_t>(plaintext), encoding_attributes);
                 
                 if (!encrypt_result || !encrypt_result->success()) {
@@ -325,7 +325,7 @@ public:
             std::cout << "Binary size: " << float_binary_data.size() << " bytes" << std::endl;
             
             // Encrypt the float data
-            std::map<std::string, std::string> float_encoding_attributes = {{"format", "PLAIN"}};
+            std::map<std::string, std::string> float_encoding_attributes = {{"page_encoding", "PLAIN"}};
             auto encrypt_result = float_agent_->Encrypt(span<const uint8_t>(float_binary_data), float_encoding_attributes);
             
             if (!encrypt_result || !encrypt_result->success()) {
@@ -424,7 +424,7 @@ public:
             std::cout << "Total size: " << fixed_length_data.size() << " bytes" << std::endl;
             
             // Test encryption with FIXED_LEN_BYTE_ARRAY and datatype_length
-            std::map<std::string, std::string> fixed_len_encoding_attributes = {{"format", "PLAIN"}};
+            std::map<std::string, std::string> fixed_len_encoding_attributes = {{"page_encoding", "PLAIN"}};
             auto encrypt_result = fixed_len_agent_->Encrypt(span<const uint8_t>(fixed_length_data), fixed_len_encoding_attributes);
             
             if (!encrypt_result || !encrypt_result->success()) {
@@ -477,7 +477,7 @@ public:
         std::cout << "\nTesting empty data handling:" << std::endl;
         try {
             std::vector<uint8_t> empty_data;
-            std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+            std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
             auto result = agent_->Encrypt(span<const uint8_t>(empty_data), encoding_attributes);
             
             if (result && result->success()) {
@@ -496,7 +496,7 @@ public:
         try {
             std::string large_data(10000, 'X');  // 10KB of data
             std::vector<uint8_t> plaintext(large_data.begin(), large_data.end());
-            std::map<std::string, std::string> encoding_attributes = {{"format", "PLAIN"}};
+            std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
             auto result = agent_->Encrypt(span<const uint8_t>(plaintext), encoding_attributes);
             
             if (result && result->success()) {

--- a/src/server/dbps_api_server.cpp
+++ b/src/server/dbps_api_server.cpp
@@ -49,6 +49,9 @@ int main() {
         response.access_control_ = "granted";
         response.reference_id_ = request.reference_id_;
         response.encrypted_compression_ = request.encrypted_compression_;
+        
+        // TODO: Use encoding_attributes in encryption sequencer
+        const auto& encoding_attributes = request.encoding_attributes_;
 
         // Use DataBatchEncryptionSequencer for actual encryption
         DataBatchEncryptionSequencer sequencer(
@@ -85,6 +88,9 @@ int main() {
             }
             return CreateErrorResponse(error_msg);
         }
+
+        // TODO: Use encoding_attributes in decryption sequencer
+        const auto& encoding_attributes = request.encoding_attributes_;
 
         // Create response using our JsonResponse class
         DecryptJsonResponse response;


### PR DESCRIPTION
- Sending encryption attributes from DBPA_external > API client > API server
- Updated json_request.cpp and json_request.h to add encryption_attributes to the request