### PR TITLE
Strip level bytes on API server

### DIFF
--- a/src/server/dbps_api_server.cpp
+++ b/src/server/dbps_api_server.cpp
@@ -50,7 +50,7 @@ int main() {
         response.reference_id_ = request.reference_id_;
         response.encrypted_compression_ = request.encrypted_compression_;
         
-        // TODO: Use encoding_attributes in encryption sequencer
+        // Use encoding_attributes in encryption sequencer
         const auto& encoding_attributes = request.encoding_attributes_;
 
         // Use DataBatchEncryptionSequencer for actual encryption
@@ -59,6 +59,7 @@ int main() {
             request.datatype_length_,
             request.compression_,
             request.format_,
+            encoding_attributes,
             request.encrypted_compression_,
             request.key_id_
         );
@@ -89,7 +90,7 @@ int main() {
             return CreateErrorResponse(error_msg);
         }
 
-        // TODO: Use encoding_attributes in decryption sequencer
+        // Use encoding_attributes in decryption sequencer
         const auto& encoding_attributes = request.encoding_attributes_;
 
         // Create response using our JsonResponse class
@@ -113,6 +114,7 @@ int main() {
             request.datatype_length_,
             request.compression_,
             request.format_,
+            encoding_attributes,
             request.encrypted_compression_,
             request.key_id_
         );

--- a/src/server/decoding_utils.h
+++ b/src/server/decoding_utils.h
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <cstring>
 #include <optional>
+#include <map>
+#include <variant>
 #include "enums.h"
 
 using namespace dbps::external;
@@ -17,6 +19,8 @@ using namespace dbps::external;
  */
 std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physical_type,
     std::optional<int> datatype_length = std::nullopt, int leading_bytes_to_strip = 0) {
+
+    // TODO: Remove these strings and use exceptions
     static constexpr const char* DECODE_ERROR_STR = "Unknown encoding";
     static constexpr const char* UNSUPPORTED_TYPE_STR = "Unsupported type";
 
@@ -155,4 +159,72 @@ std::string PrintPlainDecoded(const std::vector<uint8_t>& raw, Type::type physic
     }
 
     return out.str();
+}
+
+/**
+ * Calculates the total length of level bytes based on encoding attributes.
+ * 
+ * @param raw Raw binary data (currently unused but kept for future V1 implementation)
+ * @param encoding_attribs Converted encoding attributes map
+ * @return Total length of level bytes. Throws exceptions if calculation fails or page type is unsupported
+ */
+int CalculateLevelBytesLength(const std::vector<uint8_t>& raw,
+    const std::map<std::string, std::variant<int, bool, std::string>>& encoding_attribs) {
+    
+    // Helper function to skip V1 RLE level data in raw bytes
+    // Returns number of bytes consumed: [4-byte len] + [level bytes indicated by `len`]
+    auto SkipV1RLELevel = [&raw](size_t& offset) -> int {
+        if (offset + 4 > raw.size()) {
+            // TODO: Throw an exception
+            return -1;
+        }
+        uint32_t len = *reinterpret_cast<const uint32_t*>(raw.data() + offset);
+        if (offset + 4 + len > raw.size()) {
+            // TODO: Throw an exception
+            return -1;
+        }
+        offset += 4 + len;
+        return 4 + len;
+    };
+    
+    // Get page_type from the converted attributes
+    const std::string& page_type = std::get<std::string>(encoding_attribs.at("page_type"));
+    int total_level_bytes = 0;
+
+    if (page_type == "DATA_PAGE_V2") {
+        // For DATA_PAGE_V2: sum of definition and repetition level byte lengths
+        int def_level_length = std::get<int>(encoding_attribs.at("page_v2_definition_levels_byte_length"));
+        int rep_level_length = std::get<int>(encoding_attribs.at("page_v2_repetition_levels_byte_length"));
+        total_level_bytes = def_level_length + rep_level_length;
+        
+    } else if (page_type == "DATA_PAGE_V1") {
+        int max_rep_level = std::get<int>(encoding_attribs.at("data_page_max_repetition_level"));
+        int max_def_level = std::get<int>(encoding_attribs.at("data_page_max_definition_level"));
+
+        // if max_rep_level > 0, there are repetition levels bytes. Same for definition levels.
+        size_t offset = 0;
+        if (max_rep_level > 0) {
+            total_level_bytes += SkipV1RLELevel(offset);
+        }
+        if (max_def_level > 0) {
+            total_level_bytes += SkipV1RLELevel(offset);
+        }
+
+    } else if (page_type == "DICTIONARY_PAGE") {
+        // DICTIONARY_PAGE has no level bytes
+        total_level_bytes = 0;
+
+    } else {
+        // Unknown page type
+        // TODO: Throw an exception
+        return -1;
+    }
+
+    // Validate that the total level bytes before returning.
+    if (total_level_bytes < 0 || total_level_bytes > raw.size()) {
+        // TODO: Throw an exception
+        return -1;
+    }
+    return total_level_bytes;
+
 }

--- a/src/server/encryption_sequencer.h
+++ b/src/server/encryption_sequencer.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <variant>
+#include <map>
 #include "enums.h"
 
 using namespace dbps::external;
@@ -27,6 +29,7 @@ public:
     std::optional<int> datatype_length_;
     std::string compression_;
     std::string format_;
+    std::map<std::string, std::string> encoding_attributes_;
     std::string encrypted_compression_;
     std::string key_id_;
     
@@ -44,6 +47,7 @@ public:
         const std::optional<int>& datatype_length,
         const std::string& compression,
         const std::string& format,
+        const std::map<std::string, std::string>& encoding_attributes,
         const std::string& encrypted_compression,
         const std::string& key_id
     );
@@ -65,12 +69,23 @@ private:
     CompressionCodec::type encrypted_compression_enum_;
     Format::type format_enum_;
     
+    // Converted encoding attributes values to corresponding types
+    std::map<std::string, std::variant<int, bool, std::string>> encoding_attributes_converted_;
+    
     /**
      * Converts string values to corresponding enum values using enum_utils.
      * Returns true if all conversions are successful, false otherwise.
      * Sets error_stage_ and error_message_ if conversion fails.
      */
     bool ConvertStringsToEnums();
+    
+    /**
+     * Converts encoding attributes string values to corresponding typed values.
+     * Reads specific keys from encoding_attributes_ corresponding to Parquet encoding attributes.
+     * Returns true if all conversions are successful, false otherwise.
+     * Sets error_stage_ and error_message_ if conversion fails.
+     */
+    bool ConvertEncodingAttributesToValues();
     
     /**
      * Performs comprehensive validation of all parameters and key_id.


### PR DESCRIPTION
- Parsing encoding attributes to values on encryption sequencer.
- Adding calculation of level bytes length to decoding utils.
- Using calculation of level bytes length to determine leading bytes to strip on encryption sequencer.