### PR TITLE
Update JsonRequest library to receive a binary value and encrypted_value instead of base64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ target_include_directories(dbps_common_lib PUBLIC
   src/common
   src/common/tcb
   ${CMAKE_BINARY_DIR}/_deps/crow-src/include
+  ${CMAKE_BINARY_DIR}/_deps/cppcodec-src
 )
 
 # Server components library

--- a/src/client/dbps_api_client_test.cpp
+++ b/src/client/dbps_api_client_test.cpp
@@ -12,6 +12,11 @@
 using namespace dbps::external;
 using namespace dbps::enum_utils;
 
+// Helper function to convert string to binary data
+std::vector<uint8_t> StringToBytes(const std::string& str) {
+    return std::vector<uint8_t>(str.begin(), str.end());
+}
+
 // Simple test framework (matching existing project style)
 #define TEST(name) void test_##name()
 #define ASSERT(condition) assert(condition)
@@ -114,7 +119,7 @@ TEST(ApiResponseSuccessWithValidResponse) {
     
     // Create a valid EncryptJsonResponse
     EncryptJsonResponse json_response;
-    json_response.encrypted_value_ = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
+    json_response.encrypted_value_ = StringToBytes("test@example.com");
     json_response.encrypted_compression_ = CompressionCodec::UNCOMPRESSED;
     json_response.user_id_ = "test_user";
     json_response.role_ = "test_role";
@@ -134,7 +139,7 @@ TEST(ApiResponseSuccessWithInvalidHttpStatus) {
     
     // Create a valid EncryptJsonResponse
     EncryptJsonResponse json_response;
-    json_response.encrypted_value_ = "dGVzdEBleGFtcGxlLmNvbQ==";
+    json_response.encrypted_value_ = StringToBytes("test@example.com");
     json_response.encrypted_compression_ = CompressionCodec::UNCOMPRESSED;
     json_response.user_id_ = "test_user";
     json_response.role_ = "test_role";
@@ -155,7 +160,7 @@ TEST(ApiResponseSuccessWithApiClientError) {
     
     // Create a valid EncryptJsonResponse
     EncryptJsonResponse json_response;
-    json_response.encrypted_value_ = "dGVzdEBleGFtcGxlLmNvbQ==";
+    json_response.encrypted_value_ = StringToBytes("test@example.com");
     json_response.encrypted_compression_ = CompressionCodec::UNCOMPRESSED;
     json_response.user_id_ = "test_user";
     json_response.role_ = "test_role";
@@ -171,9 +176,9 @@ TEST(ApiResponseSuccessWithApiClientError) {
 TEST(EncryptApiResponseGetResponseCiphertextWithValidData) {
     TestableEncryptApiResponse response;
     
-    // Create a valid EncryptJsonResponse with base64 encoded data
+    // Create a valid EncryptJsonResponse with binary data
     EncryptJsonResponse json_response;
-    json_response.encrypted_value_ = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
+    json_response.encrypted_value_ = StringToBytes("test@example.com");
     json_response.encrypted_compression_ = CompressionCodec::UNCOMPRESSED;
     json_response.user_id_ = "test_user";
     json_response.role_ = "test_role";
@@ -208,9 +213,9 @@ TEST(EncryptApiResponseGetResponseCiphertextWithNoData) {
 TEST(DecryptApiResponseGetResponsePlaintextWithValidData) {
     TestableDecryptApiResponse response;
     
-    // Create a valid DecryptJsonResponse with base64 encoded data
+    // Create a valid DecryptJsonResponse with binary data
     DecryptJsonResponse json_response;
-    json_response.decrypted_value_ = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
+    json_response.decrypted_value_ = StringToBytes("test@example.com");
     json_response.datatype_ = Type::BYTE_ARRAY;
     json_response.compression_ = CompressionCodec::UNCOMPRESSED;
     json_response.format_ = Format::PLAIN;
@@ -292,8 +297,7 @@ TEST(EncryptWithValidData) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_plaintext = "test@example.com";
-    std::vector<uint8_t> plaintext_data(test_plaintext.begin(), test_plaintext.end());
+    std::vector<uint8_t> plaintext_data = StringToBytes("test@example.com");
     
     // Call Encrypt() with valid parameters
     auto response = client.Encrypt(
@@ -346,7 +350,7 @@ TEST(DecryptWithValidData) {
             }
         },
         "data_batch_encrypted": {
-            "value": "ZEdWemRFQmxlR0Z0Y0d4bExtTnZiUT09",
+            "value": "dGVzdEBleGFtcGxlLmNvbQ==",
             "value_format": {"compression": "UNCOMPRESSED"}
         },
         "encryption": {"key_id": "test_key_123"},
@@ -382,8 +386,7 @@ TEST(DecryptWithValidData) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_ciphertext = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
-    std::vector<uint8_t> ciphertext_data(test_ciphertext.begin(), test_ciphertext.end());
+    std::vector<uint8_t> ciphertext_data = StringToBytes("test@example.com");
     
     // Call Decrypt() with valid parameters
     auto response = client.Decrypt(
@@ -427,8 +430,7 @@ TEST(EncryptWithInvalidData) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_plaintext = "test@example.com";
-    std::vector<uint8_t> plaintext_data(test_plaintext.begin(), test_plaintext.end());
+    std::vector<uint8_t> plaintext_data = StringToBytes("test@example.com");
     
     // Test empty plaintext
     std::vector<uint8_t> empty_data;
@@ -457,8 +459,7 @@ TEST(DecryptWithInvalidData) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_ciphertext = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
-    std::vector<uint8_t> ciphertext_data(test_ciphertext.begin(), test_ciphertext.end());
+    std::vector<uint8_t> ciphertext_data = StringToBytes("test@example.com");
     
     // Test empty ciphertext
     std::vector<uint8_t> empty_data;
@@ -477,152 +478,6 @@ TEST(DecryptWithInvalidData) {
     
     // Verify the response indicates failure
     ASSERT_FALSE(response1.Success());
-}
-
-TEST(EncryptWithInvalidBase64Response) {
-    // Create mock HTTP client
-    auto mock_client = std::make_unique<MockHttpClient>();
-    
-    // Set up mock response for /encrypt endpoint with invalid base64
-    std::string expected_request = R"({
-        "column_reference": {"name": "email"},
-        "data_batch": {
-            "datatype_info": {
-                "datatype": "BYTE_ARRAY"
-            },
-            "value": "dGVzdEBleGFtcGxlLmNvbQ==",
-            "value_format": {
-                "compression": "UNCOMPRESSED",
-                "format": "PLAIN"
-            }
-        },
-        "data_batch_encrypted": {
-            "value_format": {"compression": "UNCOMPRESSED"}
-        },
-        "encryption": {"key_id": "test_key_123"},
-        "access": {"user_id": "test_user_456"},
-        "debug": {"reference_id": "1755831549871"}
-    })";
-    
-    // Response with valid JSON structure but invalid base64 value
-    std::string mock_response = R"({
-        "data_batch_encrypted": {
-            "value": "INVALID_BASE64_VALUE!!!",
-            "value_format": {
-                "compression": "UNCOMPRESSED"
-            }
-        },
-        "access": {
-            "user_id": "test_user",
-            "role": "test_role",
-            "access_control": "test_access"
-        },
-        "debug": {
-            "reference_id": "test_ref"
-        }
-    })";
-    
-    mock_client->SetMockPostResponse("/encrypt", expected_request, 
-        HttpClientInterface::HttpResponse(200, mock_response));
-    
-    // Create DBPSApiClient with mock client
-    DBPSApiClient client(std::move(mock_client));
-    
-    // Create test data
-    std::string test_plaintext = "test@example.com";
-    std::vector<uint8_t> plaintext_data(test_plaintext.begin(), test_plaintext.end());
-    
-    // Call Encrypt() with valid parameters
-    auto response = client.Encrypt(
-        span<const uint8_t>(plaintext_data),
-        "email",                    // column_name
-        Type::BYTE_ARRAY,           // datatype
-        std::nullopt,               // datatype_length
-        CompressionCodec::UNCOMPRESSED, // compression
-        Format::PLAIN,         // format
-        std::map<std::string, std::string>{}, // encoding_attributes
-        CompressionCodec::UNCOMPRESSED, // encrypted_compression
-        "test_key_123",             // key_id
-        "test_user_456"             // user_id
-    );
-    
-    // Verify the response indicates failure
-    ASSERT_FALSE(response.Success());
-}
-
-TEST(DecryptWithInvalidBase64Response) {
-    // Create mock HTTP client
-    auto mock_client = std::make_unique<MockHttpClient>();
-    
-    // Set up mock response for /decrypt endpoint with invalid base64
-    std::string expected_request = R"({
-        "column_reference": {"name": "email"},
-        "data_batch": {
-            "datatype_info": {
-                "datatype": "BYTE_ARRAY"
-            },
-            "value_format": {
-                "compression": "UNCOMPRESSED",
-                "format": "PLAIN"
-            }
-        },
-        "data_batch_encrypted": {
-            "value": "ZEdWemRFQmxlR0Z0Y0d4bExtTnZiUT09",
-            "value_format": {"compression": "UNCOMPRESSED"}
-        },
-        "encryption": {"key_id": "test_key_123"},
-        "access": {"user_id": "test_user_456"},
-        "debug": {"reference_id": "1755831549871"}
-    })";
-    
-    // Response with valid JSON structure but invalid base64 value
-    std::string mock_response = R"({
-        "data_batch": {
-            "datatype_info": {
-                "datatype": "BYTE_ARRAY"
-            },
-            "value": "INVALID_BASE64_VALUE!!!",
-            "value_format": {
-                "compression": "UNCOMPRESSED",
-                "format": "PLAIN"
-            }
-        },
-        "access": {
-            "user_id": "test_user",
-            "role": "test_role",
-            "access_control": "test_access"
-        },
-        "debug": {
-            "reference_id": "test_ref"
-        }
-    })";
-    
-    mock_client->SetMockPostResponse("/decrypt", expected_request, 
-        HttpClientInterface::HttpResponse(200, mock_response));
-    
-    // Create DBPSApiClient with mock client
-    DBPSApiClient client(std::move(mock_client));
-    
-    // Create test data
-    std::string test_ciphertext = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
-    std::vector<uint8_t> ciphertext_data(test_ciphertext.begin(), test_ciphertext.end());
-    
-    // Call Decrypt() with valid parameters
-    auto response = client.Decrypt(
-        span<const uint8_t>(ciphertext_data),
-        "email",                    // column_name
-        Type::BYTE_ARRAY,           // datatype
-        std::nullopt,               // datatype_length
-        CompressionCodec::UNCOMPRESSED, // compression
-        Format::PLAIN,         // format
-        std::map<std::string, std::string>{}, // encoding_attributes
-        CompressionCodec::UNCOMPRESSED, // encrypted_compression
-        "test_key_123",             // key_id
-        "test_user_456"             // user_id
-    );
-    
-    // Verify the response indicates failure
-    ASSERT_FALSE(response.Success());
 }
 
 TEST(EncryptWithInvalidJsonResponse) {
@@ -668,8 +523,7 @@ TEST(EncryptWithInvalidJsonResponse) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_plaintext = "test@example.com";
-    std::vector<uint8_t> plaintext_data(test_plaintext.begin(), test_plaintext.end());
+    std::vector<uint8_t> plaintext_data = StringToBytes("test@example.com");
     
     // Call Encrypt() with valid parameters
     auto response = client.Encrypt(
@@ -706,7 +560,7 @@ TEST(DecryptWithInvalidJsonResponse) {
             }
         },
         "data_batch_encrypted": {
-            "value": "ZEdWemRFQmxlR0Z0Y0d4bExtTnZiUT09",
+            "value": "dGVzdEBleGFtcGxlLmNvbQ==",
             "value_format": {"compression": "UNCOMPRESSED"}
         },
         "encryption": {"key_id": "test_key_123"},
@@ -732,8 +586,7 @@ TEST(DecryptWithInvalidJsonResponse) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_ciphertext = "dGVzdEBleGFtcGxlLmNvbQ=="; // "test@example.com" in base64
-    std::vector<uint8_t> ciphertext_data(test_ciphertext.begin(), test_ciphertext.end());
+    std::vector<uint8_t> ciphertext_data = StringToBytes("test@example.com");
     
     // Call Decrypt() with valid parameters
     auto response = client.Decrypt(
@@ -807,8 +660,7 @@ TEST(EncryptWithEncodingAttributes) {
     DBPSApiClient client(std::move(mock_client));
     
     // Create test data
-    std::string test_plaintext = "test@example.com";
-    std::vector<uint8_t> plaintext_data(test_plaintext.begin(), test_plaintext.end());
+    std::vector<uint8_t> plaintext_data = StringToBytes("test@example.com");
     
     // Create encoding_attributes map
     std::map<std::string, std::string> encoding_attributes;
@@ -936,22 +788,6 @@ int main() {
         PrintTestResult("Decrypt with invalid data", true);
     } catch (...) {
         PrintTestResult("Decrypt with invalid data", false);
-        all_tests_passed = false;
-    }
-    
-    try {
-        test_EncryptWithInvalidBase64Response();
-        PrintTestResult("Encrypt with invalid base64 response", true);
-    } catch (...) {
-        PrintTestResult("Encrypt with invalid base64 response", false);
-        all_tests_passed = false;
-    }
-    
-    try {
-        test_DecryptWithInvalidBase64Response();
-        PrintTestResult("Decrypt with invalid base64 response", true);
-    } catch (...) {
-        PrintTestResult("Decrypt with invalid base64 response", false);
         all_tests_passed = false;
     }
     

--- a/src/client/dbps_api_client_test.cpp
+++ b/src/client/dbps_api_client_test.cpp
@@ -12,11 +12,6 @@
 using namespace dbps::external;
 using namespace dbps::enum_utils;
 
-// Helper function to convert string to binary data
-std::vector<uint8_t> StringToBytes(const std::string& str) {
-    return std::vector<uint8_t>(str.begin(), str.end());
-}
-
 // Simple test framework (matching existing project style)
 #define TEST(name) void test_##name()
 #define ASSERT(condition) assert(condition)
@@ -27,6 +22,11 @@ std::vector<uint8_t> StringToBytes(const std::string& str) {
 // Test utilities
 void PrintTestResult(const std::string& test_name, bool passed) {
     std::cout << (passed ? "PASS" : "FAIL") << ": " << test_name << std::endl;
+}
+
+// Helper function to convert string to binary data
+std::vector<uint8_t> StringToBytes(const std::string& str) {
+    return std::vector<uint8_t>(str.begin(), str.end());
 }
 
 // Utility function to compare JSON strings, ignoring specified fields

--- a/src/client/dbps_api_client_test.cpp
+++ b/src/client/dbps_api_client_test.cpp
@@ -24,6 +24,7 @@ void PrintTestResult(const std::string& test_name, bool passed) {
     std::cout << (passed ? "PASS" : "FAIL") << ": " << test_name << std::endl;
 }
 
+// TODO: Move this to a common test utility file.
 // Helper function to convert string to binary data
 std::vector<uint8_t> StringToBytes(const std::string& str) {
     return std::vector<uint8_t>(str.begin(), str.end());

--- a/src/common/json_request.h
+++ b/src/common/json_request.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <optional>
 #include <map>
+#include <cstdint>
 #include "enums.h"
 #include "enum_utils.h"
 
@@ -90,7 +91,7 @@ protected:
 class EncryptJsonRequest : public JsonRequest {
 public:
     // Encrypt-specific required fields
-    std::string value_;
+    std::vector<uint8_t> value_;
     
     /**
      * Default constructor.
@@ -130,7 +131,7 @@ protected:
 class DecryptJsonRequest : public JsonRequest {
 public:
     // Decrypt-specific required fields
-    std::string encrypted_value_;
+    std::vector<uint8_t> encrypted_value_;
     
     /**
      * Default constructor.
@@ -227,7 +228,7 @@ class EncryptJsonResponse : public JsonResponse {
 public:
     // Encrypt-specific required fields
     std::optional<CompressionCodec::type> encrypted_compression_;
-    std::string encrypted_value_;
+    std::vector<uint8_t> encrypted_value_;
     
     /**
      * Default constructor.
@@ -271,7 +272,7 @@ public:
     std::optional<int> datatype_length_;
     std::optional<CompressionCodec::type> compression_;
     std::optional<Format::type> format_;
-    std::string decrypted_value_;
+    std::vector<uint8_t> decrypted_value_;
     
     /**
      * Default constructor.

--- a/src/server/dbps_api_server.cpp
+++ b/src/server/dbps_api_server.cpp
@@ -54,9 +54,6 @@ int main() {
         response.reference_id_ = request.reference_id_;
         response.encrypted_compression_ = request.encrypted_compression_;
         
-        // Use encoding_attributes in encryption sequencer
-        const auto& encoding_attributes = request.encoding_attributes_;
-
         // Use DataBatchEncryptionSequencer for actual encryption
         // It is safe to use value() because the request is validated above.
         DataBatchEncryptionSequencer sequencer(
@@ -64,7 +61,7 @@ int main() {
             request.datatype_length_,
             request.compression_.value(),
             request.format_.value(),
-            encoding_attributes,
+            request.encoding_attributes_,
             request.encrypted_compression_.value(),
             request.key_id_
         );
@@ -100,9 +97,6 @@ int main() {
         std::cout << request.ToJson() << std::endl;
         std::cout << "=====================================" << std::endl;
 
-        // Use encoding_attributes in decryption sequencer
-        const auto& encoding_attributes = request.encoding_attributes_;
-
         // Create response using our JsonResponse class
         DecryptJsonResponse response;
         
@@ -125,7 +119,7 @@ int main() {
             request.datatype_length_,
             request.compression_.value(),
             request.format_.value(),
-            encoding_attributes,
+            request.encoding_attributes_,
             request.encrypted_compression_.value(),
             request.key_id_
         );

--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -1,11 +1,11 @@
 #include "encryption_sequencer.h"
 #include "enum_utils.h"
 #include "decoding_utils.h"
-#include <cppcodec/base64_rfc4648.hpp>
 #include <functional>
 #include <iostream>
 #include <sstream>
 #include <optional>
+#include <cassert>
 
 using namespace dbps::external;
 using namespace dbps::enum_utils;
@@ -28,7 +28,7 @@ DataBatchEncryptionSequencer::DataBatchEncryptionSequencer(
     key_id_(key_id) {}
 
 // Main processing methods
-bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::string& plaintext) {
+bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::vector<uint8_t>& plaintext) {
     // Validate all parameters and key_id
     if (!ValidateParameters()) {
         return false;
@@ -41,13 +41,8 @@ bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::string& plaintex
         return false;
     }
     
-    // Decode the base64 plaintext to get the original binary data
-    std::vector<uint8_t> decoded_data = DecodeBase64(plaintext);
-    if (decoded_data.empty()) {
-        error_stage_ = "base64_decoding";
-        error_message_ = "Failed to decode base64 plaintext";
-        return false;
-    }
+    // The plaintext is in binary format, so we can use it directly
+    const std::vector<uint8_t>& decoded_data = plaintext;
     
     // Integration point for data element based encryptors.
     // - Currently, the function simply prints the decoded plaintext data (for uncompressed data and PLAIN format)
@@ -78,25 +73,17 @@ bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::string& plaintex
     }
     
     // Simple XOR encryption
-    std::vector<uint8_t> encrypted_data = EncryptData(decoded_data);
-    if (encrypted_data.empty()) {
+    encrypted_result_ = EncryptData(decoded_data);
+    if (encrypted_result_.empty()) {
         error_stage_ = "encryption";
         error_message_ = "Failed to encrypt data";
-        return false;
-    }
-    
-    // Encode encrypted data back to base64
-    encrypted_result_ = EncodeBase64(encrypted_data);
-    if (encrypted_result_.empty()) {
-        error_stage_ = "base64_encoding";
-        error_message_ = "Failed to encode encrypted data to base64";
         return false;
     }
     
     return true;
 }
 
-bool DataBatchEncryptionSequencer::ConvertAndDecrypt(const std::string& ciphertext) {
+bool DataBatchEncryptionSequencer::ConvertAndDecrypt(const std::vector<uint8_t>& ciphertext) {
     // Validate all parameters and key_id
     if (!ValidateParameters()) {
         return false;
@@ -109,27 +96,14 @@ bool DataBatchEncryptionSequencer::ConvertAndDecrypt(const std::string& cipherte
         return false;
     }
     
-    // Decode the base64 ciphertext to get the encrypted binary data
-    std::vector<uint8_t> encrypted_data = DecodeBase64(ciphertext);
-    if (encrypted_data.empty()) {
-        error_stage_ = "base64_decoding";
-        error_message_ = "Failed to decode base64 ciphertext";
-        return false;
-    }
+    // The ciphertext is in binary format, so we can use it directly
+    const std::vector<uint8_t>& encrypted_data = ciphertext;
     
     // Simple XOR decryption (same operation as encryption)
-    std::vector<uint8_t> decrypted_data = DecryptData(encrypted_data);
-    if (decrypted_data.empty()) {
+    decrypted_result_ = DecryptData(encrypted_data);
+    if (decrypted_result_.empty()) {
         error_stage_ = "decryption";
         error_message_ = "Failed to decrypt data";
-        return false;
-    }
-    
-    // Encode decrypted data back to base64
-    decrypted_result_ = EncodeBase64(decrypted_data);
-    if (decrypted_result_.empty()) {
-        error_stage_ = "base64_encoding";
-        error_message_ = "Failed to encode decrypted data to base64";
         return false;
     }
     
@@ -246,26 +220,6 @@ bool DataBatchEncryptionSequencer::ValidateParameters() {
     }
     
     return true;
-}
-
-std::vector<uint8_t> DataBatchEncryptionSequencer::DecodeBase64(const std::string& base64_string) {
-    try {
-        // Use cppcodec library for robust base64 decoding
-        return cppcodec::base64_rfc4648::decode(base64_string);
-    } catch (const std::exception& e) {
-        // Return empty vector on any decoding error
-        return std::vector<uint8_t>();
-    }
-}
-
-std::string DataBatchEncryptionSequencer::EncodeBase64(const std::vector<uint8_t>& data) {
-    try {
-        // Use cppcodec library for robust base64 encoding
-        return cppcodec::base64_rfc4648::encode(data);
-    } catch (const std::exception& e) {
-        // Return empty string on any encoding error
-        return "";
-    }
 }
 
 std::vector<uint8_t> DataBatchEncryptionSequencer::EncryptData(const std::vector<uint8_t>& data) {

--- a/src/server/encryption_sequencer.h
+++ b/src/server/encryption_sequencer.h
@@ -26,22 +26,13 @@ using namespace dbps::external;
  */
 class DataBatchEncryptionSequencer {
 public:
-    // TODO: Move these to protected attributes if no external access is needed.
-    Type::type datatype_;
-    std::optional<int> datatype_length_;
-    CompressionCodec::type compression_;
-    Format::type format_;
-    std::map<std::string, std::string> encoding_attributes_;
-    CompressionCodec::type encrypted_compression_;
-    std::string key_id_;
+    // Result storage
+    std::vector<uint8_t> encrypted_result_;
+    std::vector<uint8_t> decrypted_result_;
     
     // Error reporting fields
     std::string error_stage_;
     std::string error_message_;
-    
-    // Result storage
-    std::vector<uint8_t> encrypted_result_;
-    std::vector<uint8_t> decrypted_result_;
     
     // Constructor - simple setter of parameters
     DataBatchEncryptionSequencer(
@@ -65,6 +56,15 @@ public:
     bool ConvertAndDecrypt(const std::vector<uint8_t>& ciphertext);
 
 protected:
+    // Parameters for encryption/decryption operations
+    Type::type datatype_;
+    std::optional<int> datatype_length_;
+    CompressionCodec::type compression_;
+    Format::type format_;
+    std::map<std::string, std::string> encoding_attributes_;
+    CompressionCodec::type encrypted_compression_;
+    std::string key_id_;
+
     // Converted encoding attributes values to corresponding types
     std::map<std::string, std::variant<int32_t, bool, std::string>> encoding_attributes_converted_;
     

--- a/src/server/encryption_sequencer.h
+++ b/src/server/encryption_sequencer.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <variant>
 #include <map>
+#include <cstdint>
 #include "enums.h"
 
 using namespace dbps::external;
@@ -39,8 +40,8 @@ public:
     std::string error_message_;
     
     // Result storage
-    std::string encrypted_result_;
-    std::string decrypted_result_;
+    std::vector<uint8_t> encrypted_result_;
+    std::vector<uint8_t> decrypted_result_;
     
     // Constructor - simple setter of parameters
     DataBatchEncryptionSequencer(
@@ -60,8 +61,8 @@ public:
     ~DataBatchEncryptionSequencer() = default;
     
     // Main processing methods
-    bool ConvertAndEncrypt(const std::string& plaintext);
-    bool ConvertAndDecrypt(const std::string& ciphertext);
+    bool ConvertAndEncrypt(const std::vector<uint8_t>& plaintext);
+    bool ConvertAndDecrypt(const std::vector<uint8_t>& ciphertext);
 
 protected:
     // Converted encoding attributes values to corresponding types
@@ -82,10 +83,6 @@ protected:
      * Returns true if all validation passes, false otherwise.
      */
     bool ValidateParameters();
-    
-    // Encode-decode base64 string to binary data using cppcodec library
-    std::vector<uint8_t> DecodeBase64(const std::string& base64_string);
-    std::string EncodeBase64(const std::vector<uint8_t>& data);
     
     // Simple encryption/decryption using XOR with key_id hash
     std::vector<uint8_t> EncryptData(const std::vector<uint8_t>& data);

--- a/src/server/encryption_sequencer_test.cpp
+++ b/src/server/encryption_sequencer_test.cpp
@@ -8,6 +8,7 @@
 
 using namespace dbps::external;
 
+// TODO: Move this to a common test utility file.
 // Helper function to convert string to binary data
 std::vector<uint8_t> StringToBytes(const std::string& str) {
     return std::vector<uint8_t>(str.begin(), str.end());

--- a/src/server/encryption_sequencer_test.cpp
+++ b/src/server/encryption_sequencer_test.cpp
@@ -8,6 +8,17 @@
 
 using namespace dbps::external;
 
+// Helper function to convert string to binary data
+std::vector<uint8_t> StringToBytes(const std::string& str) {
+    return std::vector<uint8_t>(str.begin(), str.end());
+}
+
+// Test data constants - pure binary data
+const std::vector<uint8_t> HELLO_WORLD_DATA = StringToBytes("Hello, World!");
+const std::vector<uint8_t> BINARY_DATA = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};
+const std::vector<uint8_t> SINGLE_CHAR_DATA = StringToBytes("A");
+const std::vector<uint8_t> EMPTY_DATA = {};
+
 // Test class that inherits from DataBatchEncryptionSequencer to access protected members
 class TestDataBatchEncryptionSequencer : public DataBatchEncryptionSequencer {
 public:
@@ -51,11 +62,8 @@ bool TestEncryptionDecryption() {
             "test_key_123"     // key_id
         );
         
-        // Test data: "Hello, World!" in base64
-        std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
-        
         // Test encryption
-        bool encrypt_result = sequencer.ConvertAndEncrypt(test_data);
+        bool encrypt_result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!encrypt_result) {
             std::cout << "Encryption failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -72,10 +80,9 @@ bool TestEncryptionDecryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "key2"
         );
         
-        std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
         
-        bool result1 = sequencer1.ConvertAndEncrypt(test_data);
-        bool result2 = sequencer2.ConvertAndEncrypt(test_data);
+        bool result1 = sequencer1.ConvertAndEncrypt(HELLO_WORLD_DATA);
+        bool result2 = sequencer2.ConvertAndEncrypt(HELLO_WORLD_DATA);
         
         if (!result1 || !result2) {
             std::cout << "Different key encryption test failed" << std::endl;
@@ -93,10 +100,9 @@ bool TestEncryptionDecryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "same_key"
         );
         
-        std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
         
-        bool result1 = sequencer1.ConvertAndEncrypt(test_data);
-        bool result2 = sequencer2.ConvertAndEncrypt(test_data);
+        bool result1 = sequencer1.ConvertAndEncrypt(HELLO_WORLD_DATA);
+        bool result2 = sequencer2.ConvertAndEncrypt(HELLO_WORLD_DATA);
         
         if (!result1 || !result2) {
             std::cout << "Same key encryption test failed" << std::endl;
@@ -111,7 +117,7 @@ bool TestEncryptionDecryption() {
         );
         
         // This should fail because empty input is rejected
-        bool result = sequencer.ConvertAndEncrypt("");
+        bool result = sequencer.ConvertAndEncrypt(EMPTY_DATA);
         if (result) {
             std::cout << "Empty data encryption should have failed" << std::endl;
             return false;
@@ -125,9 +131,8 @@ bool TestEncryptionDecryption() {
         );
         
         // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
-        std::string binary_data = "AAECAwQF";
         
-        bool result = sequencer.ConvertAndEncrypt(binary_data);
+        bool result = sequencer.ConvertAndEncrypt(BINARY_DATA);
         if (!result) {
             std::cout << "Binary data encryption failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -144,7 +149,7 @@ bool TestParameterValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!result) {
             std::cout << "Valid parameters test failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -156,7 +161,7 @@ bool TestParameterValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::GZIP, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!result) {
             return false;
         }
@@ -171,7 +176,7 @@ bool TestParameterValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::UNDEFINED, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!result) {
             std::cout << "Format UNDEFINED should be supported: " << sequencer.error_message_ << std::endl;
             return false;
@@ -188,7 +193,7 @@ bool TestParameterValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::RLE, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!result) {
             std::cout << "Format RLE should now be supported: " << sequencer.error_message_ << std::endl;
             return false;
@@ -210,7 +215,7 @@ bool TestInputValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndEncrypt("");
+        bool result = sequencer.ConvertAndEncrypt(EMPTY_DATA);
         if (result) {
             std::cout << "Empty plaintext test should have failed" << std::endl;
             return false;
@@ -226,7 +231,7 @@ bool TestInputValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
-        bool result = sequencer.ConvertAndDecrypt("");
+        bool result = sequencer.ConvertAndDecrypt(EMPTY_DATA);
         if (result) {
             std::cout << "Empty ciphertext test should have failed" << std::endl;
             return false;
@@ -242,7 +247,7 @@ bool TestInputValidation() {
         DataBatchEncryptionSequencer sequencer(
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, ""
         );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (result) {
             std::cout << "Empty key_id test should have failed" << std::endl;
             return false;
@@ -256,92 +261,7 @@ bool TestInputValidation() {
     return true;
 }
 
-// Test base64 decoding
-bool TestBase64Decoding() {
-    // Test 1: Valid base64 - "Hello, World!"
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ==");
-        if (!result) {
-            std::cout << "Valid base64 test failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 2: Valid base64 - empty string
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("");
-        if (result) {
-            std::cout << "Empty base64 test should have failed (empty input)" << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 3: Valid base64 - single character
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("QQ=="); // "A"
-        if (!result) {
-            std::cout << "Single character base64 test failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 4: Valid base64 - binary data
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("AAECAwQF"); // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
-        if (!result) {
-            std::cout << "Binary data base64 test failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 5: Invalid base64 - garbage characters
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("InvalidBase64!@#");
-        if (result) {
-            std::cout << "Invalid base64 test should have failed" << std::endl;
-            return false;
-        }
-        if (sequencer.error_stage_ != "base64_decoding") {
-            std::cout << "Wrong error stage for invalid base64: " << sequencer.error_stage_ << std::endl;
-            return false;
-        }
-    }
-    
-    // Test 6: Invalid base64 - incomplete padding
-    {
-        DataBatchEncryptionSequencer sequencer(
-            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
-        );
-        bool result = sequencer.ConvertAndEncrypt("SGVsbG8sIFdvcmxkIQ"); // Missing padding
-        if (result) {
-            std::cout << "Incomplete padding base64 test should have failed" << std::endl;
-            return false;
-        }
-        if (sequencer.error_stage_ != "base64_decoding") {
-            std::cout << "Wrong error stage for incomplete padding: " << sequencer.error_stage_ << std::endl;
-            return false;
-        }
-    }
-    
-    return true;
-}
-
-// Test round-trip encryption/decryption with base64 verification
+// Test round-trip encryption/decryption
 bool TestRoundTripEncryption() {
     // Test 1: Basic round trip - "Hello, World!"
     {
@@ -349,10 +269,8 @@ bool TestRoundTripEncryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key_123"
         );
         
-        std::string original_base64 = "SGVsbG8sIFdvcmxkIQ=="; // "Hello, World!"
-        
         // Encrypt
-        bool encrypt_result = sequencer.ConvertAndEncrypt(original_base64);
+        bool encrypt_result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA); // "Hello, World!"
         if (!encrypt_result) {
             std::cout << "Round trip encryption failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -366,10 +284,8 @@ bool TestRoundTripEncryption() {
         }
         
         // Verify the decrypted result matches the original
-        if (sequencer.decrypted_result_ != original_base64) {
+        if (sequencer.decrypted_result_ != HELLO_WORLD_DATA) {
             std::cout << "Round trip failed: decrypted result does not match original" << std::endl;
-            std::cout << "Original: " << original_base64 << std::endl;
-            std::cout << "Decrypted: " << sequencer.decrypted_result_ << std::endl;
             return false;
         }
     }
@@ -380,10 +296,8 @@ bool TestRoundTripEncryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "binary_test_key"
         );
         
-        std::string original_base64 = "AAECAwQF"; // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
-        
         // Encrypt
-        bool encrypt_result = sequencer.ConvertAndEncrypt(original_base64);
+        bool encrypt_result = sequencer.ConvertAndEncrypt(BINARY_DATA); // Binary data: 0x00, 0x01, 0x02, 0x03, 0x04, 0x05
         if (!encrypt_result) {
             std::cout << "Binary round trip encryption failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -397,10 +311,8 @@ bool TestRoundTripEncryption() {
         }
         
         // Verify the decrypted result matches the original
-        if (sequencer.decrypted_result_ != original_base64) {
+        if (sequencer.decrypted_result_ != BINARY_DATA) {
             std::cout << "Binary round trip failed: decrypted result does not match original" << std::endl;
-            std::cout << "Original: " << original_base64 << std::endl;
-            std::cout << "Decrypted: " << sequencer.decrypted_result_ << std::endl;
             return false;
         }
     }
@@ -411,10 +323,10 @@ bool TestRoundTripEncryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "single_char_key"
         );
         
-        std::string original_base64 = "QQ=="; // "A"
+        // "A"
         
         // Encrypt
-        bool encrypt_result = sequencer.ConvertAndEncrypt(original_base64);
+        bool encrypt_result = sequencer.ConvertAndEncrypt(SINGLE_CHAR_DATA);
         if (!encrypt_result) {
             std::cout << "Single char round trip encryption failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -428,10 +340,8 @@ bool TestRoundTripEncryption() {
         }
         
         // Verify the decrypted result matches the original
-        if (sequencer.decrypted_result_ != original_base64) {
+        if (sequencer.decrypted_result_ != SINGLE_CHAR_DATA) {
             std::cout << "Single char round trip failed: decrypted result does not match original" << std::endl;
-            std::cout << "Original: " << original_base64 << std::endl;
-            std::cout << "Decrypted: " << sequencer.decrypted_result_ << std::endl;
             return false;
         }
     }
@@ -446,10 +356,8 @@ bool TestRoundTripEncryption() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "key2"
         );
         
-        std::string original_base64 = "SGVsbG8sIFdvcmxkIQ==";
-        
-        bool result1 = sequencer1.ConvertAndEncrypt(original_base64);
-        bool result2 = sequencer2.ConvertAndEncrypt(original_base64);
+        bool result1 = sequencer1.ConvertAndEncrypt(HELLO_WORLD_DATA);
+        bool result2 = sequencer2.ConvertAndEncrypt(HELLO_WORLD_DATA);
         
         if (!result1 || !result2) {
             std::cout << "Different keys test failed during encryption" << std::endl;
@@ -471,7 +379,7 @@ bool TestRoundTripEncryption() {
             return false;
         }
         
-        if (sequencer1.decrypted_result_ != original_base64 || sequencer2.decrypted_result_ != original_base64) {
+        if (sequencer1.decrypted_result_ != HELLO_WORLD_DATA || sequencer2.decrypted_result_ != HELLO_WORLD_DATA) {
             std::cout << "Different keys test: decrypted results should match original" << std::endl;
             return false;
         }
@@ -480,7 +388,7 @@ bool TestRoundTripEncryption() {
     return true;
 }
 
-// Test result storage and base64 encoding
+// Test result storage
 bool TestResultStorage() {
     // Test 1: Verify encrypted result is stored
     {
@@ -488,9 +396,7 @@ bool TestResultStorage() {
             Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key"
         );
         
-        std::string original_base64 = "SGVsbG8sIFdvcmxkIQ==";
-        
-        bool result = sequencer.ConvertAndEncrypt(original_base64);
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!result) {
             std::cout << "Result storage encryption test failed: " << sequencer.error_stage_ << " - " << sequencer.error_message_ << std::endl;
             return false;
@@ -502,14 +408,8 @@ bool TestResultStorage() {
             return false;
         }
         
-        if (sequencer.encrypted_result_ == original_base64) {
+        if (sequencer.encrypted_result_ == HELLO_WORLD_DATA) {
             std::cout << "encrypted_result_ should be different from input" << std::endl;
-            return false;
-        }
-        
-        // Verify it's valid base64
-        if (sequencer.encrypted_result_.find_first_not_of("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=") != std::string::npos) {
-            std::cout << "encrypted_result_ should contain only valid base64 characters" << std::endl;
             return false;
         }
     }
@@ -521,8 +421,7 @@ bool TestResultStorage() {
         );
         
         // First encrypt something
-        std::string original_base64 = "SGVsbG8sIFdvcmxkIQ==";
-        bool encrypt_result = sequencer.ConvertAndEncrypt(original_base64);
+        bool encrypt_result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (!encrypt_result) {
             std::cout << "Result storage decryption test failed during encryption" << std::endl;
             return false;
@@ -541,10 +440,8 @@ bool TestResultStorage() {
             return false;
         }
         
-        if (sequencer.decrypted_result_ != original_base64) {
+        if (sequencer.decrypted_result_ != HELLO_WORLD_DATA) {
             std::cout << "decrypted_result_ should match original input" << std::endl;
-            std::cout << "Original: " << original_base64 << std::endl;
-            std::cout << "Decrypted: " << sequencer.decrypted_result_ << std::endl;
             return false;
         }
     }
@@ -554,7 +451,6 @@ bool TestResultStorage() {
 
 // Test FIXED_LEN_BYTE_ARRAY validation
 bool TestFixedLenByteArrayValidation() {
-    const std::string test_data = "SGVsbG8sIFdvcmxkIQ==";
     
     // Helper function to test validation failure
     auto testValidationFailure = [&](const std::optional<int>& datatype_length, const std::string& expected_msg) -> bool {
@@ -562,7 +458,7 @@ bool TestFixedLenByteArrayValidation() {
             Type::FIXED_LEN_BYTE_ARRAY, datatype_length, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key_123"
         );
         
-        bool result = sequencer.ConvertAndEncrypt(test_data);
+        bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
         if (result) {
             std::cout << "ERROR: Should have failed validation" << std::endl;
             return false;
@@ -584,7 +480,7 @@ bool TestFixedLenByteArrayValidation() {
     
     // Test valid case (should pass parameter validation)
     DataBatchEncryptionSequencer sequencer(Type::FIXED_LEN_BYTE_ARRAY, 16, CompressionCodec::UNCOMPRESSED, Format::PLAIN, {{"page_type", "DICTIONARY_PAGE"}}, CompressionCodec::UNCOMPRESSED, "test_key_123");
-    bool result = sequencer.ConvertAndEncrypt(test_data);
+    bool result = sequencer.ConvertAndEncrypt(HELLO_WORLD_DATA);
     
     if (!result && sequencer.error_stage_ == "parameter_validation") {
         std::cout << "ERROR: Valid datatype_length should pass parameter validation" << std::endl;
@@ -744,9 +640,6 @@ int main() {
     
     all_tests_passed &= TestInputValidation();
     PrintTestResult("Input Validation", all_tests_passed);
-    
-    all_tests_passed &= TestBase64Decoding();
-    PrintTestResult("Base64 Decoding", all_tests_passed);
     
     all_tests_passed &= TestEncryptionDecryption();
     PrintTestResult("Encryption/Decryption", all_tests_passed);


### PR DESCRIPTION
- The PR makes a correction by pushing the base64 encoding (which is only needed during RPC call) inside JsonRequest library instead of requiring the library users to encode/decode base64.
- Updating to use base64 encoded data in the json_request and json_response only.
- Moving users of json_request library to pass the data as binary data.