### PR TITLE
Defining a Connection pool for HTTPLib (#138)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ target_include_directories(dbps_server_lib PUBLIC
 add_library(dbps_client_lib STATIC 
   src/client/dbps_api_client.cpp
   src/client/httplib_client.cpp
+  src/client/httplib_pool_registry.cpp
+  src/client/httplib_pooled_client.cpp
 )
 target_link_libraries(dbps_client_lib PUBLIC dbps_common_lib)
 target_include_directories(dbps_client_lib PUBLIC
@@ -203,6 +205,22 @@ if(BUILD_TESTS)
   )
   target_include_directories(dbps_api_client_test PRIVATE
     ${CMAKE_BINARY_DIR}/_deps/crow-src/include
+  )
+
+  # Pool registry tests
+  add_executable(httplib_pool_registry_test src/client/httplib_pool_registry_test.cpp)
+  target_link_libraries(httplib_pool_registry_test 
+    dbps_client_lib
+    dbps_common_lib
+    gtest_main
+  )
+
+  # Pooled client tests
+  add_executable(httplib_pooled_client_test src/client/httplib_pooled_client_test.cpp)
+  target_link_libraries(httplib_pooled_client_test 
+    dbps_client_lib
+    dbps_common_lib
+    gtest_main
   )
 
   # Remote DBPA tests
@@ -331,6 +349,8 @@ if(BUILD_TESTS)
       dbps_api_client_test
       dbpa_remote_test
       dbpa_local_test
+      httplib_pool_registry_test
+      httplib_pooled_client_test
     COMMENT "Building all tests"
   )
 endif()

--- a/src/client/httplib_pool_registry.cpp
+++ b/src/client/httplib_pool_registry.cpp
@@ -1,0 +1,126 @@
+#include "httplib_pool_registry.h"
+
+// Meyer's singleton
+// This is thread-safe since C++11 (we use C++17)
+// https://laristra.github.io/flecsi/src/developer-guide/patterns/meyers_singleton.html
+// https://stackoverflow.com/questions/17712001/how-is-meyers-implementation-of-a-singleton-actually-a-singleton
+HttplibPoolRegistry& HttplibPoolRegistry::Instance() {
+    static HttplibPoolRegistry instance;
+    return instance;
+}
+
+void HttplibPoolRegistry::SetPoolConfig(const std::string& base_url, const PoolConfig& config) {
+    std::lock_guard<std::mutex> lock(registry_mutex_);
+    auto& pool = url_to_pool_[base_url];
+    pool.config = config;
+}
+
+HttplibPoolRegistry::PoolState& HttplibPoolRegistry::GetOrCreatePool(
+        const std::string& base_url) {
+    std::lock_guard<std::mutex> lock(registry_mutex_);
+    auto it = url_to_pool_.find(base_url);
+
+    // we did not find a pool for this base_url, so we create a new one
+    if (it == url_to_pool_.end()) {
+        // Construct the PoolState in-place to avoid copying/moving non-copyable members.
+        auto inserted = url_to_pool_.try_emplace(base_url);
+        it = inserted.first;
+        // Default config
+        it->second.config.max_pool_size = kDefaultMaxPoolSize;
+        it->second.config.borrow_timeout = kDefaultBorrowTimeout_ms;
+        it->second.config.max_idle_time = kDefaultMaxIdleTime_ms;
+        it->second.config.connect_timeout = kDefaultConnectTimeout_s;
+        it->second.config.read_timeout = kDefaultReadTimeout_s;
+        it->second.config.write_timeout = kDefaultWriteTimeout_s;
+    }
+    return it->second;
+}
+
+std::unique_ptr<httplib::Client> HttplibPoolRegistry::CreateClient(const std::string& base_url, const PoolConfig& cfg) const {
+    std::unique_ptr<httplib::Client> client(new httplib::Client(base_url));
+    client->set_connection_timeout(static_cast<int>(cfg.connect_timeout.count()));
+    client->set_read_timeout(static_cast<int>(cfg.read_timeout.count()));
+    client->set_write_timeout(static_cast<int>(cfg.write_timeout.count()));
+    client->set_keep_alive(true);
+    return client;
+}
+
+std::unique_ptr<httplib::Client> HttplibPoolRegistry::Borrow(const std::string& base_url) {
+    PoolState& pool = GetOrCreatePool(base_url);
+
+    const auto deadline = std::chrono::steady_clock::now() + pool.config.borrow_timeout;
+    std::unique_lock<std::mutex> lock(pool.mutex);
+
+    // first iterate through the idle list and prune any clients that have been idle for too long
+    // then check if there are any clients in the idle list that can be returned
+    // if there are no clients in the idle list, create a new client
+    // if no new client can be created, wait (via cv.wait_until()) 
+    // for a client to be returned to the pool or for the borrow timeout to expire
+    while (true) {
+        // Prune idle
+        const auto now = std::chrono::steady_clock::now();
+        while (!pool.idle.empty()) {
+            const auto& entry = pool.idle.front();
+            if (now - entry.last_used > pool.config.max_idle_time) {
+                pool.idle.pop_front();
+                if (pool.total_clients > 0) {
+                    pool.total_clients = pool.total_clients - 1;
+                }
+            } else {
+                break;
+            }
+        }
+
+        if (!pool.idle.empty()) {
+            auto entry = std::move(pool.idle.front());
+            pool.idle.pop_front();
+            return std::move(entry.client);
+        }
+
+        if (pool.total_clients < pool.config.max_pool_size) {
+            ++pool.total_clients;
+            lock.unlock();
+            auto client = CreateClient(base_url, pool.config);
+            lock.lock();
+            return client;
+        }
+
+        // if we get here, we have no clients in the idle list and no capacity to create a new client
+        // so we wait for a client to be returned to the pool or for the borrow timeout to expire
+        
+        // the mutex can be unlocked here either when a client is returned to the pool
+        // (via the Return() function) or when we timed out.
+        // if we time out and, return a null pointer
+        if (pool.cv.wait_until(lock, deadline) == std::cv_status::timeout) {
+            return std::unique_ptr<httplib::Client>();
+        }
+    }
+}
+
+void HttplibPoolRegistry::Return(const std::string& base_url, std::unique_ptr<httplib::Client> client) {
+    PoolState& pool = GetOrCreatePool(base_url);
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    pool.idle.push_back(PooledEntry{ std::move(client), std::chrono::steady_clock::now() });
+    pool.cv.notify_one();
+}
+
+void HttplibPoolRegistry::Discard(const std::string& base_url, std::unique_ptr<httplib::Client> client) {
+    // Take ownership of the client by value so callers cannot reuse it after discarding.
+    // We intentionally do not return it to the idle list; destruction of the unique_ptr
+    // at the end of this function will close the underlying connection.
+    
+    // No explicit close is required here: when this function returns and 'client' goes out
+    // of scope, its destructor (via std::unique_ptr) will invoke the httplib::Client
+    // destructor, which closes the underlying socket.
+    (void)client; // Currently unused; kept for potential future diagnostics/cleanup.
+    PoolState& pool = GetOrCreatePool(base_url);
+    std::lock_guard<std::mutex> lock(pool.mutex);
+    // Adjust the total number of tracked clients since one is being discarded.
+    if (pool.total_clients > 0) {
+        pool.total_clients = pool.total_clients - 1;
+    }
+    // Wake one waiter so it can attempt to borrow/create now that capacity freed.
+    pool.cv.notify_one();
+}
+
+

--- a/src/client/httplib_pool_registry.h
+++ b/src/client/httplib_pool_registry.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include <httplib.h>
+
+// This class registers and manages a pool of connections for specific URLS.
+// It is a singleton, accessed via the Instance() function.
+class HttplibPoolRegistry {
+public:
+    // Default configuration constants for PoolConfig
+    static constexpr std::size_t kDefaultMaxPoolSize = 8;
+    static constexpr std::chrono::milliseconds kDefaultBorrowTimeout_ms{100};
+    static constexpr std::chrono::milliseconds kDefaultMaxIdleTime_ms{60*1000}; // 60 seconds
+    static constexpr std::chrono::seconds kDefaultConnectTimeout_s{5};
+    static constexpr std::chrono::seconds kDefaultReadTimeout_s{20};
+    static constexpr std::chrono::seconds kDefaultWriteTimeout_s{20};
+
+    struct PoolConfig {
+        // Maximum number of live clients allowed in the pool for a base URL
+        std::size_t max_pool_size;
+
+        // Maximum time to wait to borrow a client before giving up (null returned)
+        // Units: milliseconds
+        std::chrono::milliseconds borrow_timeout;
+
+        // Maximum time an idle client is kept in the pool before being pruned
+        // Units: milliseconds
+        std::chrono::milliseconds max_idle_time;
+
+        // Connection timeout applied to underlying httplib::Client
+        // Units: seconds
+        std::chrono::seconds connect_timeout;
+
+        // Read timeout applied to underlying httplib::Client
+        // Units: seconds
+        std::chrono::seconds read_timeout;
+
+        // Write timeout applied to underlying httplib::Client
+        // Units: seconds
+        std::chrono::seconds write_timeout;
+    };
+
+    // Returns a singleton reference to the registry.
+    // Call is thread-safe.
+    static HttplibPoolRegistry& Instance();
+
+    // Ensure pool exists for base_url and set/overwrite its configuration.
+    // Can be invoked before of after the pool is created/used.
+    void SetPoolConfig(const std::string& base_url, const PoolConfig& config);
+
+    // Borrow/Return/Discard client for base_url.
+    std::unique_ptr<httplib::Client> Borrow(const std::string& base_url);
+    void Return(const std::string& base_url, std::unique_ptr<httplib::Client> client);
+    void Discard(const std::string& base_url, std::unique_ptr<httplib::Client> client);
+
+private:
+    HttplibPoolRegistry() {}
+    HttplibPoolRegistry(const HttplibPoolRegistry&); // not implemented
+    HttplibPoolRegistry& operator=(const HttplibPoolRegistry&); // not implemented
+
+    struct PooledEntry {
+        std::unique_ptr<httplib::Client> client;
+        std::chrono::steady_clock::time_point last_used;
+    };
+
+    struct PoolState {
+        PoolConfig config;
+        std::mutex mutex;
+        std::condition_variable cv;
+        std::deque<PooledEntry> idle;
+        std::size_t total_clients = 0;
+    };
+
+    // Returns reference to PoolState for base_url, creating it if not present with default config.
+    PoolState& GetOrCreatePool(const std::string& base_url);
+
+    // Create and configure a new client for base_url.
+    std::unique_ptr<httplib::Client> CreateClient(const std::string& base_url, const PoolConfig& cfg) const;
+
+    // Map access
+    std::mutex registry_mutex_;
+    std::map<std::string, PoolState> url_to_pool_;
+};
+
+

--- a/src/client/httplib_pool_registry_test.cpp
+++ b/src/client/httplib_pool_registry_test.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <string>
+#include <thread>
+#include "httplib_pool_registry.h"
+
+TEST(HttplibPoolRegistryTest, SingletonInstanceIsSame) {
+    auto* a = &HttplibPoolRegistry::Instance();
+    auto* b = &HttplibPoolRegistry::Instance();
+    EXPECT_EQ(a, b);
+}
+
+TEST(HttplibPoolRegistryTest, BorrowReturnReuse) {
+    auto& reg = HttplibPoolRegistry::Instance();
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 2;
+    cfg.borrow_timeout = std::chrono::milliseconds(50);
+    cfg.max_idle_time = std::chrono::milliseconds(5000);
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    const std::string url = "http://127.0.0.1:65535";
+
+    reg.SetPoolConfig(url, cfg);
+    auto c1 = reg.Borrow(url);
+    ASSERT_TRUE(c1);
+    auto raw1 = c1.get();
+    reg.Return(url, std::move(c1));
+
+    auto c2 = reg.Borrow(url);
+    ASSERT_TRUE(c2);
+    auto raw2 = c2.get();
+    EXPECT_EQ(raw1, raw2);
+    reg.Return(url, std::move(c2));
+}
+
+TEST(HttplibPoolRegistryTest, MaxPoolSizeAndBorrowTimeout) {
+    auto& reg = HttplibPoolRegistry::Instance();
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 1;
+    cfg.borrow_timeout = std::chrono::milliseconds(30);
+    cfg.max_idle_time = std::chrono::milliseconds(5000);
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    const std::string url = "http://127.0.0.1:65534";
+
+    reg.SetPoolConfig(url, cfg);
+    auto c1 = reg.Borrow(url);
+    ASSERT_TRUE(c1);
+
+    // With pool at capacity and nothing returned, next borrow should time out
+    auto start = std::chrono::steady_clock::now();
+    auto c2 = reg.Borrow(url);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+    EXPECT_FALSE(c2);
+    EXPECT_GE(elapsed.count(), 25); // roughly >= borrow_timeout
+
+    reg.Return(url, std::move(c1));
+}
+
+TEST(HttplibPoolRegistryTest, IdlePruneCreatesFresh) {
+    auto& reg = HttplibPoolRegistry::Instance();
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 2;
+    cfg.borrow_timeout = std::chrono::milliseconds(50);
+    cfg.max_idle_time = std::chrono::milliseconds(10);
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    const std::string url = "http://127.0.0.1:65533";
+
+    reg.SetPoolConfig(url, cfg);
+    auto c1 = reg.Borrow(url);
+    ASSERT_TRUE(c1);
+    auto raw1 = c1.get();
+    reg.Return(url, std::move(c1));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    auto c2 = reg.Borrow(url);
+    ASSERT_TRUE(c2);
+    (void)raw1; // Address comparison is not reliable across allocators; pointer can be reused.
+    auto raw2 = c2.get();
+    ASSERT_NE(raw2, nullptr);
+    reg.Return(url, std::move(c2));
+}
+
+

--- a/src/client/httplib_pooled_client.cpp
+++ b/src/client/httplib_pooled_client.cpp
@@ -1,0 +1,208 @@
+#include "httplib_pooled_client.h"
+
+#include <httplib.h>
+#include "httplib_pool_registry.h"
+
+std::mutex HttplibPooledClient::url_to_instance_mutex_;
+std::map<std::string, std::weak_ptr<HttplibPooledClient> > HttplibPooledClient::url_to_instance_;
+
+std::shared_ptr<HttplibPooledClient> HttplibPooledClient::Acquire(
+    const std::string& base_url,
+    std::size_t num_worker_threads) {
+
+    std::lock_guard<std::mutex> lock(url_to_instance_mutex_);
+
+    auto it = url_to_instance_.find(base_url);
+    if (it != url_to_instance_.end()) {
+        // url_to_instance_ stores weak_ptr to avoid keeping instances alive unnecessarily.
+        // weak_ptr::lock() attempts to promote to a shared_ptr; it returns an empty shared_ptr
+        // if the instance has expired. When lock() succeeds, we can reuse the existing instance.
+        // the if statement will evaluate to false if the instance has expired, 
+        // and a new instance will be created in the code below.
+        if (auto existing = it->second.lock()) {
+            return existing;
+        }
+    }
+    // if no value provided for num_worker_threads, default it to 2 x "hardware_concurrency" (with a min of 2 threads)
+    // ("hardware_concurrency" is the reported number of threads that can be run concurrently (only a hint))
+    if (num_worker_threads == 0) {
+        auto hc = std::thread::hardware_concurrency();
+        num_worker_threads = hc == 0 ? 2 : std::max<std::size_t>(2, hc * 2);
+    }
+
+    auto instance = std::shared_ptr<HttplibPooledClient>(
+        new HttplibPooledClient(base_url, num_worker_threads));
+    url_to_instance_[base_url] = instance;
+    return instance;
+}
+
+HttplibPooledClient::HttplibPooledClient(const std::string& base_url,
+                                         std::size_t num_worker_threads)
+    : base_url_(base_url) {
+        
+    // reserve the space for the worker_threads_ vector
+    // this is more efficient than calling emplace_back multiple times
+    worker_threads_.reserve(num_worker_threads);
+    for (std::size_t i = 0; i < num_worker_threads; ++i) {
+        worker_threads_.emplace_back(&HttplibPooledClient::WorkerLoop, this);
+    }
+}
+
+HttplibPooledClient::~HttplibPooledClient() noexcept {
+    {
+        std::lock_guard<std::mutex> lock(request_queue_mutex_);
+        stopping_ = true;
+    }
+    request_queue_cv_.notify_all();
+    for (auto& t : worker_threads_) {
+        if (t.joinable()) t.join();
+    }
+    // Drain queue: set all promises with error to avoid hanging callers
+    while (true) {
+        std::unique_ptr<RequestTask> task;
+        {
+            std::lock_guard<std::mutex> lock(request_queue_mutex_);
+            if (request_queue_.empty()) break;
+            task = std::move(request_queue_.front());
+            request_queue_.pop_front();
+        }
+        if (task) {
+            task->promise.set_value(HttpResponse(0, "", "client shutting down"));
+        }
+    }
+}
+
+HttpClientInterface::HttpResponse HttplibPooledClient::Get(const std::string& endpoint) {
+    std::unique_ptr<RequestTask> task(new RequestTask());
+    task->kind = RequestTask::Kind::Get;
+    task->endpoint = endpoint;
+    std::future<HttpResponse> response_future = task->promise.get_future();
+    {
+        std::lock_guard<std::mutex> lock(request_queue_mutex_);
+        if (stopping_) {
+            return HttpResponse(0, "", "client shutting down");
+        }
+        request_queue_.push_back(std::move(task));
+    }
+    request_queue_cv_.notify_one();
+
+    // wait for the task to complete, and return the result
+    // (from the callers perspective, this is a blocking/synchronous call)
+    return response_future.get();
+}
+
+HttpClientInterface::HttpResponse HttplibPooledClient::Post(const std::string& endpoint, const std::string& json_body) {
+    std::unique_ptr<RequestTask> task(new RequestTask());
+    task->kind = RequestTask::Kind::Post;
+    task->endpoint = endpoint;
+    task->json_body = json_body;
+    std::future<HttpResponse> fut = task->promise.get_future();
+    {
+        std::lock_guard<std::mutex> lock(request_queue_mutex_);
+        if (stopping_) {
+            return HttpResponse(0, "", "client shutting down");
+        }
+        request_queue_.push_back(std::move(task));
+    }
+    request_queue_cv_.notify_one();
+
+    // wait for the task to complete, and return the result
+    // (from the callers perspective, this is a blocking/synchronous call)
+    return fut.get();
+}
+
+// Worker thread main loop:
+// - Waits for tasks on the queue (or shutdown signal).
+// - Borrows a client from HttplibPoolRegistry for base_url_.
+// - Executes the HTTP operation (GET/POST). On transport failure/exception,
+//   discards the client and retries once with a fresh client.
+// - Returns healthy clients to the pool; discards unhealthy ones.
+// - On shutdown, exits when the queue is empty; remaining tasks are completed
+//   with an error by the destructor after threads join.
+void HttplibPooledClient::WorkerLoop() {
+    auto& registry = HttplibPoolRegistry::Instance();
+
+    while (true) {
+        std::unique_ptr<RequestTask> task;
+        {
+            std::unique_lock<std::mutex> lock(request_queue_mutex_);
+            // Wait until either a shutdown is requested or there is at least one task to process.
+            // Using the predicate protects against spurious wakeups: the call returns only when
+            // 'stopping_' is true or 'request_queue_' is non-empty.
+            request_queue_cv_.wait(lock, [&]{ return stopping_ || !request_queue_.empty(); });
+            if (stopping_ && request_queue_.empty()) return;
+            task = std::move(request_queue_.front());
+            request_queue_.pop_front();
+        }
+
+        // Borrow client
+        // Attempts to get a connection from the per-base_url pool. If the pool cannot
+        // provide a client within its configured borrow timeout, Borrow() returns null.
+        // In that case, we complete the task with a timeout error and move on to the
+        // next queued task.
+        auto client = registry.Borrow(base_url_);
+        if (!client) {
+            task->promise.set_value(HttpResponse(0, "", "pool borrow timeout"));
+            continue;
+        }
+
+        // Helper lambda to perform the actual HTTP operation.
+        // It attempts to execute the task (GET/POST) using the borrowed client.
+        // If the operation fails, it returns a failure pair with an error response.
+        // If successful, it returns a success pair with the response.
+        auto perform_once = [&](RequestTask& t) -> std::pair<bool, HttpResponse> {
+            try {
+                if (t.kind == RequestTask::Kind::Get) {
+                    //TODO: these are hardcoded and copied from  httplib_client.cpp
+                    // we should move them to a common place (header file).
+                    httplib::Headers headers = {
+                        {"Accept", "application/json"},
+                        {"User-Agent", "DBPSApiClient/1.0"}
+                    };
+                    auto res = client->Get(t.endpoint, headers);
+                    if (!res) return {false, HttpResponse(0, "", "HTTP GET failed")};
+                    return {true, HttpResponse(res->status, res->body)};
+                } else {
+                    //TODO: these are hardcoded and copied from  httplib_client.cpp
+                    // we should move them to a common place (header file).
+                    httplib::Headers headers = {
+                        {"Content-Type", "application/json"},
+                        {"Accept", "application/json"},
+                        {"User-Agent", "DBPSApiClient/1.0"}
+                    };
+                    auto res = client->Post(t.endpoint, headers, t.json_body, "application/json");
+                    if (!res) return {false, HttpResponse(0, "", "HTTP POST failed")};
+                    return {true, HttpResponse(res->status, res->body)};
+                }
+            } catch (const std::exception& e) {
+                return {false, HttpResponse(0, "", std::string("HTTP exception: ") + e.what())};
+            }
+        };
+
+        // First attempt
+        std::pair<bool, HttpResponse> attempt1 = perform_once(*task);
+        if (attempt1.first) {
+            registry.Return(base_url_, std::move(client));
+            task->promise.set_value(attempt1.second);
+            continue;
+        }
+
+        // Retry once with a fresh client
+        registry.Discard(base_url_, std::move(client));
+        client = registry.Borrow(base_url_);
+        if (!client) {
+            task->promise.set_value(HttpResponse(0, "", "pool borrow timeout after retry"));
+            continue;
+        }
+        std::pair<bool, HttpResponse> attempt2 = perform_once(*task);
+        if (attempt2.first) {
+            registry.Return(base_url_, std::move(client));
+            task->promise.set_value(attempt2.second);
+        } else {
+            registry.Discard(base_url_, std::move(client));
+            task->promise.set_value(attempt2.second);
+        }
+    }
+} //HttplibPooledClient::WorkerLoop()
+
+

--- a/src/client/httplib_pooled_client.h
+++ b/src/client/httplib_pooled_client.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <condition_variable>
+#include <deque>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "http_client_interface.h"
+
+// Implemenetation of the HttpClientInterface which uses a pool of connections for a given base_url.
+// This is a singleton, accessed via the Acquire() function.
+class HttplibPooledClient : public HttpClientInterface {
+public:
+    // Factory that returns one pooled client per base_url.
+    // If cfg is provided, it will be applied to the underlying pool for the base_url.
+    static std::shared_ptr<HttplibPooledClient> Acquire(
+        const std::string& base_url,
+        std::size_t num_worker_threads = 0);
+
+    ~HttplibPooledClient() noexcept;
+
+    // HttpClientInterface
+    HttpResponse Get(const std::string& endpoint) override;
+    HttpResponse Post(const std::string& endpoint, const std::string& json_body) override;
+
+    // disable the copy constructor
+    HttplibPooledClient(const HttplibPooledClient&) = delete;
+    HttplibPooledClient& operator=(const HttplibPooledClient&) = delete;
+
+private:
+    explicit HttplibPooledClient(const std::string& base_url,
+                                 std::size_t num_worker_threads);
+
+    struct RequestTask {
+        enum class Kind { Get, Post };
+        Kind kind;
+        std::string endpoint;
+        std::string json_body;
+        std::promise<HttpClientInterface::HttpResponse> promise;
+    };
+
+    void WorkerLoop();
+
+    // Queue
+    std::mutex request_queue_mutex_;
+    std::condition_variable request_queue_cv_;
+    std::deque<std::unique_ptr<RequestTask> > request_queue_;
+    bool stopping_ = false;
+
+    // Workers
+    std::vector<std::thread> worker_threads_;
+
+    // Configuration
+    const std::string base_url_;
+
+    // Static per-base_url registry
+    static std::mutex url_to_instance_mutex_;
+    static std::map<std::string, std::weak_ptr<HttplibPooledClient> > url_to_instance_;
+};

--- a/src/client/httplib_pooled_client_test.cpp
+++ b/src/client/httplib_pooled_client_test.cpp
@@ -1,0 +1,157 @@
+#include <gtest/gtest.h>
+#include <chrono>
+#include <atomic>
+#include <future>
+#include <string>
+#include <thread>
+#include <httplib.h>
+#include "httplib_pooled_client.h"
+#include "httplib_pool_registry.h"
+
+TEST(HttplibPooledClientTest, AcquireSingletonPerBaseUrl) {
+    auto a = HttplibPooledClient::Acquire("http://127.0.0.1:18080", 2);
+    auto b = HttplibPooledClient::Acquire("http://127.0.0.1:18080", 2);
+    EXPECT_EQ(a.get(), b.get());
+}
+
+TEST(HttplibPooledClientTest, DifferentBaseUrlsYieldDifferentInstances) {
+    auto a = HttplibPooledClient::Acquire("http://127.0.0.1:18080", 2);
+    auto b = HttplibPooledClient::Acquire("http://127.0.0.1:18081", 2);
+    EXPECT_NE(a.get(), b.get());
+}
+
+TEST(HttplibPooledClientTest, BasicPostEcho) {
+    httplib::Server svr;
+    svr.Post("/echo", [](const httplib::Request& req, httplib::Response& res) {
+        res.set_content(req.body, "application/json");
+    });
+
+    //this is a test. use a random port.
+    int port = svr.bind_to_any_port("127.0.0.1");
+    ASSERT_GT(port, 0);
+    std::thread t([&]{ svr.listen_after_bind(); });
+
+    std::string base = std::string("http://127.0.0.1:") + std::to_string(port);
+
+    // Configure short timeouts for tests
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 4;
+    cfg.borrow_timeout = std::chrono::milliseconds(100);
+    cfg.max_idle_time = std::chrono::milliseconds(1000);
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    HttplibPoolRegistry::Instance().SetPoolConfig(base, cfg);
+
+    auto client = HttplibPooledClient::Acquire(base, 2);
+    auto resp = client->Post("/echo", "{\"ok\":true}");
+    EXPECT_GE(resp.status_code, 200);
+    EXPECT_LT(resp.status_code, 300);
+    EXPECT_EQ(resp.result, "{\"ok\":true}");
+
+    svr.stop();
+    t.join();
+}
+
+TEST(HttplibPooledClientTest, RetryOnFirstTransportFailure) {
+    // Prepare server but delay listen to force the first client attempt to fail fast.
+    httplib::Server svr;
+    svr.Post("/echo", [](const httplib::Request& req, httplib::Response& res) {
+        res.set_content(req.body, "application/json");
+    });
+
+    //this is a test. use a random port.
+    int port = svr.bind_to_any_port("127.0.0.1");
+    ASSERT_GT(port, 0);
+
+    std::string base = std::string("http://127.0.0.1:") + std::to_string(port);
+
+    // Configure short connect timeout so the first attempt fails quickly while not listening.
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 2;
+    cfg.borrow_timeout = std::chrono::milliseconds(200);
+    cfg.max_idle_time = std::chrono::milliseconds(1000);
+    cfg.connect_timeout = std::chrono::seconds(0); // 0 means no timeout in some libs; ensure >=1
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    HttplibPoolRegistry::Instance().SetPoolConfig(base, cfg);
+
+    auto client = HttplibPooledClient::Acquire(base, 2);
+
+    // Start listening shortly after to allow retry to succeed.
+    std::thread server_thread([&]{
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        svr.listen_after_bind();
+    });
+
+    auto start = std::chrono::steady_clock::now();
+    auto resp = client->Post("/echo", "{\"ok\":true}");
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start).count();
+
+    EXPECT_GE(resp.status_code, 200);
+    EXPECT_LT(resp.status_code, 300);
+    EXPECT_EQ(resp.result, "{\"ok\":true}");
+    // Should complete reasonably quickly (< ~2s given short timeouts)
+    EXPECT_LT(elapsed_ms, 2000);
+
+    svr.stop();
+    server_thread.join();
+}
+
+TEST(HttplibPooledClientTest, ConcurrencyAndThroughput) {
+    // Server that tracks max concurrent requests.
+    std::atomic<int> in_flight(0);
+    std::atomic<int> max_concurrent(0);
+    httplib::Server svr;
+    svr.new_task_queue = [] { return new httplib::ThreadPool(8); };
+    svr.Post("/work", [&](const httplib::Request& req, httplib::Response& res) {
+        int now = ++in_flight;
+        while (true) {
+            int prev = max_concurrent.load();
+            if (now > prev) { if (max_concurrent.compare_exchange_weak(prev, now)) break; }
+            else break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        --in_flight;
+        res.set_content(req.body, "application/json");
+    });
+    int port = svr.bind_to_any_port("127.0.0.1");
+    ASSERT_GT(port, 0);
+    std::thread t([&]{ svr.listen_after_bind(); });
+
+    std::string base = std::string("http://127.0.0.1:") + std::to_string(port);
+    HttplibPoolRegistry::PoolConfig cfg;
+    cfg.max_pool_size = 8;
+    cfg.borrow_timeout = std::chrono::milliseconds(200);
+    cfg.max_idle_time = std::chrono::milliseconds(1000);
+    cfg.connect_timeout = std::chrono::seconds(1);
+    cfg.read_timeout = std::chrono::seconds(1);
+    cfg.write_timeout = std::chrono::seconds(1);
+    HttplibPoolRegistry::Instance().SetPoolConfig(base, cfg);
+
+    auto client = HttplibPooledClient::Acquire(base, 4);
+
+    const int N = 24;
+    std::vector<std::future<HttpClientInterface::HttpResponse> > futures;
+    futures.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        futures.emplace_back(std::async(std::launch::async, [client]{
+            return client->Post("/work", "{\"n\":1}");
+        }));
+    }
+    int ok = 0;
+    for (auto& f : futures) {
+        auto r = f.get();
+        if (r.status_code >= 200 && r.status_code < 300) ++ok;
+    }
+    EXPECT_EQ(ok, N);
+    // Expect some parallelism observed at server
+    EXPECT_GE(max_concurrent.load(), 2);
+
+    svr.stop();
+    t.join();
+}
+
+


### PR DESCRIPTION
Defining a Connection pool for HTTPLib Client.

- Added connection pooling and a pooled HTTP client with a producer-consumer execution model.
-  `HttplibPoolRegistry` (global, per-URL connection pools)
    - Owns and manages a pool of httplib::Client instances per base URL.
    - Enforces max_pool_size, timeouts, idle pruning, Borrow/Return/Discard.
- `HttplibPooledClient`
    - New implementation of`HttpClientInterface` with internal producer-consumer queue and worker threads.
    - One instance per base URL (via Acquire(base_url)); internally uses worker threads and a task queue.
    - For each request, a worker borrows a client from the registry, executes the request, returns or discards it, and retries once on transport failure.

**Testing**
- New tests pass.
- Manually tested the new implementation of `dbpa_remote.cpp` using Arrow code (both `base_app.py` and the matrix-param test `parquet-external-dbpa-encryption-integ-test`).

