### PR TITLE
Reading Connection Pool configuration for DBPA Remote

### DIFF
--- a/src/common/dbpa_remote.h
+++ b/src/common/dbpa_remote.h
@@ -11,6 +11,7 @@
 #include "enums.h"
 #include "dbpa_interface.h"
 #include "../client/dbps_api_client.h"
+#include "../client/httplib_pool_registry.h"
 #include <nlohmann/json.hpp>
 
 #ifndef DBPS_EXPORT
@@ -111,6 +112,10 @@ protected:
     std::string server_url_;
     std::string user_id_;
     std::string k_connection_config_key_ = "connection_config_file_path";
+
+    // Extract pool config from connection_config
+    // assumes all values in connection_config are optional, and will use default values if any not present.
+    HttplibPoolRegistry::PoolConfig ExtractPoolConfig(const nlohmann::json& config_json);
 
 private:
     // Helper methods for configuration parsing


### PR DESCRIPTION
`Reading Connection Pool configuration for DBPA Remote (cont'd of #138)`

In earlier PR (https://github.com/protegrity/DataBatchProtectionService/pull/139), we configured a connection pool for DBPA Remote. However, some of the parameters for the pool were not passed and we used defaults. 

In this PR, we allow parameter passing for configuring the Connection Pool.

Paramaters for configuring the Conn Pool are passed inside the `connection_config` file (not the struct), and are defined as a flat list of parameters pre-fixed with `connection_pool`. The `connection_config` json file now looks similar to

```
{
  "server_url": "http://192.168.1.86:18080",
  "connection_pool.max_pool_size": 23,
  "connection_pool.borrow_timeout_milliseconds": 100,
  "connection_pool.max_idle_time_milliseconds": 60000,
  "connection_pool.connect_timeout_seconds": 5,
  "connection_pool.read_timeout_seconds": 20,
  "connection_pool.write_timeout_seconds": 20
}
```

**Testing**
- Existing and new tests pass
- Manual testing using `base_app.py` in Arrow