### PR TITLE
Adding the ability to pass-in and obtain column-level encryption metadata

### DIFF
--- a/src/common/dbpa_interface.h
+++ b/src/common/dbpa_interface.h
@@ -46,6 +46,11 @@ public:
     // Success flag; false indicates an error.
     virtual bool success() const = 0;
 
+    //TODO: revisit the default implementation.
+    virtual const std::optional<std::map<std::string, std::string>> encryption_metadata() const {
+        return std::nullopt;
+    }
+
     // Error details (valid when success() == false).
     virtual const std::string& error_message() const = 0;
     virtual const std::map<std::string, std::string>& error_fields() const = 0;
@@ -84,7 +89,8 @@ public:
         std::string column_key_id,
         Type::type datatype,
         std::optional<int> datatype_length,
-        CompressionCodec::type compression_type)
+        CompressionCodec::type compression_type,
+        std::optional<std::map<std::string, std::string>> column_encryption_metadata)
     {
         column_name_ = std::move(column_name);
         connection_config_ = std::move(connection_config);
@@ -93,6 +99,7 @@ public:
         datatype_ = datatype;
         datatype_length_ = datatype_length;
         compression_type_ = compression_type;
+        column_encryption_metadata_ = std::move(column_encryption_metadata);
     }
 
     /*
@@ -113,12 +120,17 @@ public:
         span<const uint8_t> ciphertext,
         std::map<std::string, std::string> encoding_attributes) = 0;
 
+    virtual const std::optional<std::map<std::string, std::string>> EncryptionMetadata() const {
+        return column_encryption_metadata_;
+    }
+
     virtual ~DataBatchProtectionAgentInterface() = default;
 
 protected:
     std::string column_name_;
     std::map<std::string, std::string> connection_config_;
     std::string app_context_;  // includes user_id
+    std::optional<std::map<std::string, std::string>> column_encryption_metadata_;
 
     std::string column_key_id_;
     Type::type datatype_;

--- a/src/common/dbpa_local.cpp
+++ b/src/common/dbpa_local.cpp
@@ -93,7 +93,8 @@ void LocalDataBatchProtectionAgent::init(
     std::string column_key_id,
     Type::type datatype,
     std::optional<int> datatype_length,
-    CompressionCodec::type compression_type) {
+    CompressionCodec::type compression_type,
+    std::optional<std::map<std::string, std::string>> column_encryption_metadata) {
 
     std::cerr << "INFO: LocalDataBatchProtectionAgent::init() - Starting initialization for column: " << column_name << std::endl;
     initialized_ = "Agent not properly initialized - incomplete";
@@ -107,7 +108,8 @@ void LocalDataBatchProtectionAgent::init(
             std::move(column_key_id),
             datatype,
             datatype_length,
-            compression_type
+            compression_type,
+            std::move(column_encryption_metadata)
         );
 
         // Check for app_context not empty (as user_id will be extracted from it)

--- a/src/common/dbpa_local.h
+++ b/src/common/dbpa_local.h
@@ -90,7 +90,8 @@ public:
         std::string column_key_id,
         Type::type datatype,
         std::optional<int> datatype_length,
-        CompressionCodec::type compression_type) override;
+        CompressionCodec::type compression_type,
+        std::optional<std::map<std::string, std::string>> column_encryption_metadata) override;
     
     std::unique_ptr<EncryptionResult> Encrypt(
         span<const uint8_t> plaintext,

--- a/src/common/dbpa_local_test.cpp
+++ b/src/common/dbpa_local_test.cpp
@@ -21,7 +21,7 @@ TEST_F(LocalDataBatchProtectionAgentTest, SuccessfulEncryption) {
     std::string app_context = R"({"user_id": "test_user"})";
     
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}, {"page_type", "DICTIONARY_PAGE"}};
@@ -40,7 +40,7 @@ TEST_F(LocalDataBatchProtectionAgentTest, SuccessfulDecryption) {
     std::string app_context = R"({"user_id": "test_user"})";
     
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}, {"page_type", "DICTIONARY_PAGE"}};
@@ -89,7 +89,7 @@ TEST_F(LocalDataBatchProtectionAgentTest, MissingUserId) {
     std::string app_context = R"({"role": "admin"})";
     
     EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED), DBPSException);
+                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt), DBPSException);
 }
 
 // Test missing page_encoding in encoding_attributes
@@ -100,7 +100,7 @@ TEST_F(LocalDataBatchProtectionAgentTest, MissingPageEncoding) {
     std::string app_context = R"({"user_id": "test_user"})";
     
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {{"page_type", "DICTIONARY_PAGE"}};

--- a/src/common/dbpa_remote.cpp
+++ b/src/common/dbpa_remote.cpp
@@ -140,7 +140,8 @@ void RemoteDataBatchProtectionAgent::init(
     std::string column_key_id,
     Type::type datatype,
     std::optional<int> datatype_length,
-    CompressionCodec::type compression_type) {
+    CompressionCodec::type compression_type,
+    std::optional<std::map<std::string, std::string>> column_encryption_metadata) {
 
     std::cerr << "INFO: RemoteDataBatchProtectionAgent::init() - Starting initialization for column: " << column_name << std::endl;
     initialized_ = "Agent not properly initialized - incomplete"; 
@@ -154,7 +155,8 @@ void RemoteDataBatchProtectionAgent::init(
             std::move(column_key_id),
             datatype,
             datatype_length,
-            compression_type
+            compression_type,
+            std::move(column_encryption_metadata)
         );
 
         // check for app_context not empty (as user_id will be extracted from it)

--- a/src/common/dbpa_remote.h
+++ b/src/common/dbpa_remote.h
@@ -93,7 +93,8 @@ public:
         std::string column_key_id,
         Type::type datatype,
         std::optional<int> datatype_length,
-        CompressionCodec::type compression_type) override;
+        CompressionCodec::type compression_type,
+        std::optional<std::map<std::string, std::string>> column_encryption_metadata) override;
     
     std::unique_ptr<EncryptionResult> Encrypt(
         span<const uint8_t> plaintext,

--- a/src/common/dbpa_remote_test.cpp
+++ b/src/common/dbpa_remote_test.cpp
@@ -124,7 +124,7 @@ protected:
         
         // init() should throw DBPSException for missing server URL
         EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                                Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED), 
+                                Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt), 
                      DBPSException);
         
         // Test that the initialized_ state reflects the failure
@@ -169,7 +169,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, LoadsConfigFromFileAndFailsHealthChec
     // init() should throw because health check will fail (we're using a real client with no server)
     // but it must parse config and extract values first
     EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key",
-                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED),
+                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt),
                  DBPSException);
 
     // Test that initialization variables are properly set
@@ -311,7 +311,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, MissingUserId) {
     
     // init() should throw DBPSException for missing user ID
     EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED), 
+                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt), 
                  DBPSException);
     
     // Test that the initialized_ state reflects the failure
@@ -345,7 +345,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, HealthCheckFailure) {
     
     // init() should throw DBPSException for health check failure
     EXPECT_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED), 
+                            Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt), 
                  DBPSException);
     
     // Test that the initialized_ state reflects the failure
@@ -389,7 +389,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulEncryption) {
     
     // init() should not throw an exception for valid configuration
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
@@ -431,7 +431,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, SuccessfulDecryption) {
     
     // init() should not throw an exception for valid configuration
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {{"page_encoding", "PLAIN"}};
@@ -501,7 +501,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, DecryptionFieldMismatch) {
         
         // init() should not throw an exception for valid configuration
         EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                                   Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                                   Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
         
         std::vector<uint8_t> test_data = {1, 2, 3, 4};
         std::map<std::string, std::string> encoding_attributes = {
@@ -544,7 +544,7 @@ TEST_F(RemoteDataBatchProtectionAgentTest, EncryptionFieldMismatch) {
     
     // init() should not throw an exception for valid configuration
     EXPECT_NO_THROW(agent.init("test_column", connection_config, app_context, "test_key", 
-                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED));
+                               Type::BYTE_ARRAY, std::nullopt, CompressionCodec::UNCOMPRESSED, std::nullopt));
     
     std::vector<uint8_t> test_data = {1, 2, 3, 4};
     std::map<std::string, std::string> encoding_attributes = {

--- a/src/scripts/dbpa_remote_testapp.cpp
+++ b/src/scripts/dbpa_remote_testapp.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include <cstring>
+#include <optional>
 #include <cxxopts.hpp>
 
 // Include the necessary headers from the project
@@ -66,7 +67,8 @@ public:
                 "demo_key_001",                // column_key_id
                 Type::UNDEFINED,               // datatype
                 std::nullopt,                  // datatype_length (not needed for UNDEFINED)
-                CompressionCodec::UNCOMPRESSED // compression_type
+                CompressionCodec::UNCOMPRESSED, // compression_type
+                std::nullopt
             );
             
             std::cout << "OK: Main DBPA agent initialized successfully" << std::endl;
@@ -92,7 +94,8 @@ public:
                 "demo_float_key_001",          // column_key_id
                 Type::FLOAT,                   // datatype
                 std::nullopt,                  // datatype_length (not needed for FLOAT)
-                CompressionCodec::UNCOMPRESSED // compression_type
+                CompressionCodec::UNCOMPRESSED, // compression_type
+                std::nullopt
             );
             
             std::cout << "OK: Float DBPA agent initialized successfully" << std::endl;
@@ -118,7 +121,8 @@ public:
                 "demo_fixed_len_key_001",      // column_key_id
                 Type::FIXED_LEN_BYTE_ARRAY,   // datatype
                 8,                            // datatype_length (8 bytes per element)
-                CompressionCodec::UNCOMPRESSED // compression_type
+                CompressionCodec::UNCOMPRESSED, // compression_type
+                std::nullopt
             );
             
             std::cout << "OK: Fixed-length DBPA agent initialized successfully" << std::endl;


### PR DESCRIPTION
Adding the ability to pass-in and obtain column-level encryption metadata

Context here. https://github.com/protegrity/arrow/issues/190

Please focus on the changes in `dbpa_interface.h` . I modified the rest of the repo to comply to the new interface, however the priority here is to make sure we're onboard with the new version of `dbpa_interface.h`

Feedback sought: 
(1) variable/method names (and method signatures)


