### PR TITLE
Allow remote DBPS client to read num_worker_threads from config (#156)

### DIFF
--- a/src/common/dbpa_remote.h
+++ b/src/common/dbpa_remote.h
@@ -134,6 +134,8 @@ protected:
     // Extract pool config from connection_config
     // assumes all values in connection_config are optional, and will use default values if any not present.
     HttplibPoolRegistry::PoolConfig ExtractPoolConfig(const nlohmann::json& config_json);
+    // Extract number of worker threads for pooled client; defaults to 0 (auto)
+    std::size_t ExtractNumWorkerThreads(const nlohmann::json& config_json) const;
 
 private:
     // Helper methods for configuration parsing


### PR DESCRIPTION
Allow remote DBPS client to read num_worker_threads from config (#156)

Existing and new test pass.