### PR TITLE
Add C++ CI workflow configuration

### DIFF
--- a/.github/workflows/cpp_tests.yml
+++ b/.github/workflows/cpp_tests.yml
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: C++ Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test-ubuntu:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build cmake g++ git libboost-date-time-dev libboost-system-dev libboost-filesystem-dev nlohmann-json3-dev
+
+      - name: Configure (CMake)
+        run: cmake -B build -S . -G Ninja 
+
+      - name: Build
+        run: cmake --build build --target all_targets
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure --parallel 2
+
+      - name: Upload test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ctest-logs
+          path: |
+            build/Testing/Temporary/LastTest.log
+            build/Testing/Temporary/CTestCostData.txt


### PR DESCRIPTION
Adding a Github Workflow Action to run the DBPS tests after pushing the code.

**Testing**
- Verified that the actions run successfully in the dev branch: https://github.com/protegrity/DataBatchProtectionService/actions/runs/19447784317