### PR TITLE
Adding datatype parameter to DBPSEncryptor constructor.

### DIFF
--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -48,10 +48,11 @@ static std::unique_ptr<DBPSEncryptor> CreateEncryptor(
     const std::string& key_id,
     const std::string& column_name,
     const std::string& user_id,
-    const std::string& application_context) {
+    const std::string& application_context,
+    Type::type datatype) {
 
     // Return a BasicEncryptor instance.
-    return std::make_unique<BasicEncryptor>(key_id, column_name, user_id, application_context);
+    return std::make_unique<BasicEncryptor>(key_id, column_name, user_id, application_context, datatype);
 }
 
 // Constructor implementation
@@ -78,7 +79,7 @@ DataBatchEncryptionSequencer::DataBatchEncryptionSequencer(
     user_id_(user_id),
     application_context_(application_context),
     encryption_metadata_(encryption_metadata),
-    encryptor_(CreateEncryptor(key_id, column_name, user_id, application_context)) {}
+    encryptor_(CreateEncryptor(key_id, column_name, user_id, application_context, datatype)) {}
 
 // Constructor with pre-built encryptor
 DataBatchEncryptionSequencer::DataBatchEncryptionSequencer(

--- a/src/server/encryptors/basic_encryptor.cpp
+++ b/src/server/encryptors/basic_encryptor.cpp
@@ -18,6 +18,7 @@
 #include "basic_encryptor.h"
 #include "../decoding_utils.h"
 #include "../exceptions.h"
+#include "../../common/enum_utils.h"
 #include <functional>
 #include <iostream>
 
@@ -65,6 +66,7 @@ std::vector<uint8_t> BasicEncryptor::EncryptValueList(
               << "  user_id: " << user_id_ << "\n"
               << "  key_id: " << key_id_ << "\n"
               << "  application_context: " << application_context_ << "\n"
+              << "  datatype: " << dbps::enum_utils::to_string(datatype_) << "\n"
               << std::endl;
 
     throw DBPSUnsupportedException("EncryptTypedList not implemented");

--- a/src/server/encryptors/basic_encryptor.h
+++ b/src/server/encryptors/basic_encryptor.h
@@ -42,13 +42,16 @@ public:
      * @param column_name The name of the column being encrypted/decrypted
      * @param user_id The user identifier for context
      * @param application_context Additional application context information
+     * @param datatype The data type of the column being encrypted/decrypted. 
+     *    It is needed for correct type specific parsing during the DecryptValueList call.
      */
     BasicEncryptor(
         const std::string& key_id,
         const std::string& column_name,
         const std::string& user_id,
-        const std::string& application_context)
-        : DBPSEncryptor(key_id, column_name, user_id, application_context) {}
+        const std::string& application_context,
+        dbps::external::Type::type datatype)
+        : DBPSEncryptor(key_id, column_name, user_id, application_context, datatype) {}
 
     ~BasicEncryptor() override = default;
 

--- a/src/server/encryptors/basic_encryptor_test.cpp
+++ b/src/server/encryptors/basic_encryptor_test.cpp
@@ -18,11 +18,14 @@
 #include "basic_encryptor.h"
 #include "../exceptions.h"
 #include "../decoding_utils.h"
+#include "../common/enums.h"
 #include <gtest/gtest.h>
 #include <vector>
 
+using namespace dbps::external;
+
 TEST(BasicEncryptor, EncryptDecryptBlock_RoundTrip) {
-    BasicEncryptor encryptor("test_key", "test_column", "test_user", "test_context");
+    BasicEncryptor encryptor("test_key", "test_column", "test_user", "test_context", Type::BYTE_ARRAY);
     
     std::vector<uint8_t> original = {1, 2, 3, 4, 5, 10, 20, 30, 40, 50};
     std::vector<uint8_t> encrypted = encryptor.EncryptBlock(original);
@@ -33,7 +36,7 @@ TEST(BasicEncryptor, EncryptDecryptBlock_RoundTrip) {
 }
 
 TEST(BasicEncryptor, EncryptBlock_EmptyData) {
-    BasicEncryptor encryptor("test_key", "test_column", "test_user", "test_context");
+    BasicEncryptor encryptor("test_key", "test_column", "test_user", "test_context", Type::BYTE_ARRAY);
     
     std::vector<uint8_t> empty;
     std::vector<uint8_t> encrypted = encryptor.EncryptBlock(empty);
@@ -42,8 +45,8 @@ TEST(BasicEncryptor, EncryptBlock_EmptyData) {
 }
 
 TEST(BasicEncryptor, EncryptBlock_DifferentKeys) {
-    BasicEncryptor encryptor1("key1", "test_column", "test_user", "test_context");
-    BasicEncryptor encryptor2("key2", "test_column", "test_user", "test_context");
+    BasicEncryptor encryptor1("key1", "test_column", "test_user", "test_context", Type::BYTE_ARRAY);
+    BasicEncryptor encryptor2("key2", "test_column", "test_user", "test_context", Type::BYTE_ARRAY);
     
     std::vector<uint8_t> data = {1, 2, 3, 4, 5};
     std::vector<uint8_t> encrypted1 = encryptor1.EncryptBlock(data);

--- a/src/server/encryptors/dbps_encryptor.h
+++ b/src/server/encryptors/dbps_encryptor.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include "../exceptions.h"
 #include "../decoding_utils.h"
+#include "../common/enums.h"
 
 #ifndef DBPS_EXPORT
 #define DBPS_EXPORT
@@ -46,16 +47,20 @@ public:
      * @param column_name The name of the column being encrypted/decrypted
      * @param user_id The user identifier for context
      * @param application_context Additional application context information
+     * @param datatype The data type of the column being encrypted/decrypted.
+     *    It is needed for correct type specific parsing during the DecryptValueList call.
      */
     DBPSEncryptor(
         const std::string& key_id,
         const std::string& column_name,
         const std::string& user_id,
-        const std::string& application_context)
+        const std::string& application_context,
+        dbps::external::Type::type datatype)
         : key_id_(key_id),
           column_name_(column_name),
           user_id_(user_id),
-          application_context_(application_context) {}
+          application_context_(application_context),
+          datatype_(datatype) {}
 
     virtual ~DBPSEncryptor() = default;
 
@@ -114,4 +119,5 @@ protected:
     std::string column_name_;
     std::string user_id_;
     std::string application_context_;
+    dbps::external::Type::type datatype_;
 };


### PR DESCRIPTION
- The datatype is needed during Decryption for correctly parsing the bytes into the type.