### PR TITLE
Enable per_value result on encryption Sequencer + Updated testing script to cover more combinations.

### DIFF
--- a/src/server/encryption_sequencer.cpp
+++ b/src/server/encryption_sequencer.cpp
@@ -140,9 +140,6 @@ bool DataBatchEncryptionSequencer::ConvertAndEncrypt(const std::vector<uint8_t>&
         // Compress the joined encrypted bytes
         encrypted_result_ = Compress(joined_encrypted_bytes, encrypted_compression_);
 
-        // TODO: Remove this once the per-value decryption implementation is complete.
-        throw DBPSUnsupportedException("Per-value encryption implementation is not complete.");
-
     } catch (const DBPSUnsupportedException& e) {
         // If any stage is as of yet unsupported, default to whole payload (per-block) encryption
         // (as opposed to per-value)


### PR DESCRIPTION
- Update of test script to add:
  (1) Compression SNAPPY
  (2) Page type: Dictionary, Data_page_v1, Data_page_v2
  (3) Encoding: PLAIN  (any others are unsupported)
  (4) DataType: BYTE_ARRAY, floats, FIXED_LEN_BYTE_ARRAY

- This is a temporary update to the testing script. A rewrite of this script is planned to tidy it up.